### PR TITLE
Minor changes to match Postgres community coding style 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*.{c,h,l,y,pl,pm}]
+indent_style = tab
+indent_size = tab
+tab_width = 4
+
+[*.{sgml,xml}]
+indent_style = space
+indent_size = 1
+
+[*.xsl]
+indent_style = space
+indent_size = 2

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -34,16 +34,17 @@ static ProcessUtility_hook_type prev_hook	= NULL;
 void _PG_init(void);
 void _PG_fini(void);
 
-static void supautils_hook(PlannedStmt *pstmt,
-						const char *queryString,
-						ProcessUtilityContext context,
-						ParamListInfo params,
-						QueryEnvironment *queryEnv,
-						DestReceiver *dest,
+static void
+supautils_hook(PlannedStmt *pstmt,
+				const char *queryString,
+				ProcessUtilityContext context,
+				ParamListInfo params,
+				QueryEnvironment *queryEnv,
+				DestReceiver *dest,
 #if PG13_GTE
-						QueryCompletion *completionTag
+				QueryCompletion *completionTag
 #else
-						char *completionTag
+				char *completionTag
 #endif
 );
 
@@ -113,10 +114,12 @@ supautils_hook(PlannedStmt *pstmt,
 	Node   *utility_stmt = pstmt->utilityStmt;
 
 	// Check reserved objects if not a superuser
-	if (!superuser()){
+	if (!superuser())
+	{
 
 		// Check if supautils.reserved_memberships is not empty
-		if(reserved_memberships){
+		if(reserved_memberships)
+		{
 			List *memberships_list;
 			char *reserved_membership = NULL;
 
@@ -139,7 +142,8 @@ supautils_hook(PlannedStmt *pstmt,
 		}
 
 		// Ditto for supautils.reserved_roles
-		if(reserved_roles){
+		if(reserved_roles)
+		{
 			List *roles_list;
 			char *reserved_role = NULL;
 
@@ -167,8 +171,8 @@ supautils_hook(PlannedStmt *pstmt,
 }
 
 /*
-  Look if the utility statement grants a reserved membership,
-  return the membership if it does
+ * Look if the utility statement grants a reserved membership,
+ * return the membership if it does
  */
 static char*
 look_for_reserved_membership(Node *utility_stmt, List *memberships_list)
@@ -182,7 +186,8 @@ look_for_reserved_membership(Node *utility_stmt, List *memberships_list)
 				GrantRoleStmt *stmt = (GrantRoleStmt *) utility_stmt;
 				ListCell *role_cell;
 
-				if(stmt->is_grant){
+				if(stmt->is_grant)
+				{
 					foreach(role_cell, stmt->granted_roles)
 					{
 						AccessPriv *priv = (AccessPriv *) lfirst(role_cell);
@@ -262,7 +267,7 @@ look_for_reserved_membership(Node *utility_stmt, List *memberships_list)
 				}
 
 				break;
-			};
+			}
 		default:
 			break;
 	}
@@ -271,8 +276,8 @@ look_for_reserved_membership(Node *utility_stmt, List *memberships_list)
 }
 
 /*
-  Look if the utility statement modifies a reserved role,
-  return the role if it does
+ * Look if the utility statement modifies a reserved role,
+ * return the role if it does
  */
 static char*
 look_for_reserved_role(Node *utility_stmt, List *roles_list)
@@ -300,7 +305,7 @@ look_for_reserved_role(Node *utility_stmt, List *roles_list)
 				}
 
 				break;
-			};
+			}
 		// ALTER ROLE <role> NOLOGIN NOINHERIT..
 		case T_AlterRoleStmt:
 			{


### PR DESCRIPTION
## What kind of change does this PR introduce?

Coding style update to match the coding style in core Postgres code.

There's no behaviour change.

## Additional context

There are 3 commits in this pull-request.

The first commit (1a977e6784184da1ed28bf6f0d3ed7ffc2c35575) removes some whitespace and blank lines to match the Postgres coding style, as documented in the community [wiki][] and [docs][]

[wiki]: https://wiki.postgresql.org/wiki/So,_you_want_to_be_a_developer%3F#Style_Guide
[docs]: https://www.postgresql.org/docs/current/source.html

The second commit (63507eae0b3b8be8472b787aba472e709752fbd6) adds `.editorconfig` file at the top-level, to aid the developers and their editors in maintaining this style. This config is copied [verbatim][] from Postgres repository.

[verbatim]: https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=.editorconfig;h=d69a3d1dc4e0a4df6623348f92c81bdd93917dec;hb=272d82ec6febb97ab25fd7c67e9c84f4660b16ac

The 3rd and final commit (3a67195cb24cf502ccdb2e4cb2b3550629ddd672) in the PR makes some minor code edits, that is not whitespace, to match Postgres coding style.