### PR TITLE
fix: don't fail on DROP ROLE IF EXISTS/ALTER TABLE RENAME

### DIFF
--- a/src/supautils.c
+++ b/src/supautils.c
@@ -340,11 +340,17 @@ look_for_reserved_role(Node *utility_stmt, List *roles_list)
 
 				break;
 			}
-		// ALTER ROLE <role> RENAME TO ...
+		// All RENAME statements are caught here
 		case T_RenameStmt:
 			{
 				RenameStmt *stmt = (RenameStmt *) utility_stmt;
+
 				ListCell *role_cell;
+
+				// Make sure we only catch
+				// ALTER ROLE <role> RENAME TO
+				if (stmt->renameType != OBJECT_ROLE)
+					break;
 
 				foreach(role_cell, roles_list)
 				{

--- a/test/expected/reserved_roles.out
+++ b/test/expected/reserved_roles.out
@@ -43,6 +43,8 @@ ERROR:  role "public" does not exist
 drop role if exists nonexistent, rol;
 NOTICE:  role "nonexistent" does not exist, skipping
 NOTICE:  role "rol" does not exist, skipping
+alter table foo rename to bar;
+ERROR:  relation "foo" does not exist
 \echo
 
 -- cannot create a reserved role that doesn't yet exist

--- a/test/expected/reserved_roles.out
+++ b/test/expected/reserved_roles.out
@@ -40,6 +40,9 @@ drop role session_user;
 ERROR:  cannot use special role specifier in DROP ROLE
 alter role public;
 ERROR:  role "public" does not exist
+drop role if exists nonexistent, rol;
+NOTICE:  role "nonexistent" does not exist, skipping
+NOTICE:  role "rol" does not exist, skipping
 \echo
 
 -- cannot create a reserved role that doesn't yet exist

--- a/test/sql/reserved_roles.sql
+++ b/test/sql/reserved_roles.sql
@@ -29,6 +29,7 @@ drop role public;
 drop role current_user;
 drop role session_user;
 alter role public;
+drop role if exists nonexistent, rol;
 \echo
 
 -- cannot create a reserved role that doesn't yet exist

--- a/test/sql/reserved_roles.sql
+++ b/test/sql/reserved_roles.sql
@@ -30,6 +30,7 @@ drop role current_user;
 drop role session_user;
 alter role public;
 drop role if exists nonexistent, rol;
+alter table foo rename to bar;
 \echo
 
 -- cannot create a reserved role that doesn't yet exist


### PR DESCRIPTION
- Closes #11: Don't use `get_rolespec_name()` on the DROP ROLE case because it validates that the ROLE exists before the standard hook can act and be lenient on DROP ROLE IF EXISTS.

- Closes #10: ALTER TABLE RENAME was failing, only catch ALTER ROLE RENAME statements and avoid processing other RENAME statements.