### PR TITLE
Restrict grant or revoke reserved roles memberships

### DIFF
--- a/src/supautils.c
+++ b/src/supautils.c
@@ -400,6 +400,28 @@ look_for_reserved_role(Node *utility_stmt, List *roles_list)
 
 				break;
 			}
+		// GRANT <role> TO <reserved_roles>
+		// REVOKE <role> FROM <reserved_roles>
+		case T_GrantRoleStmt:
+			{
+				GrantRoleStmt *stmt = (GrantRoleStmt *) utility_stmt;
+				ListCell *grantee_role_cell;
+
+				foreach(grantee_role_cell, stmt->grantee_roles)
+				{
+					AccessPriv *priv = (AccessPriv *) lfirst(grantee_role_cell);
+					ListCell *role_cell;
+					char *grantee_role = priv->priv_name;
+
+					foreach(role_cell, roles_list)
+					{
+						char *rolename = (char *) lfirst(role_cell);
+
+						if (strcmp(grantee_role, rolename) == 0)
+							return rolename;
+					}
+				}
+			}
 		default:
 			break;
 	}

--- a/test/expected/reserved_memberships.out
+++ b/test/expected/reserved_memberships.out
@@ -23,9 +23,9 @@ ERROR:  "role_with_reserved_membership" role memberships are reserved, only supe
 \echo
 
 -- can grant non-reserved memberships
-grant pg_monitor to anon;
-grant pg_read_all_settings to anon;
-grant pg_read_all_stats to anon;
+grant pg_monitor to fake;
+grant pg_read_all_settings to fake;
+grant pg_read_all_stats to fake;
 \echo
 
 -- can grant non-reserved memberships when creating a role

--- a/test/expected/reserved_roles.out
+++ b/test/expected/reserved_roles.out
@@ -62,6 +62,24 @@ drop role new_fake;
 create role non_reserved;
 \echo
 
+-- cannnot grant memberships to reserved-roles
+grant pg_monitor to anon;
+ERROR:  "anon" is a reserved role, only superusers can modify it
+grant pg_read_all_settings to anon;
+ERROR:  "anon" is a reserved role, only superusers can modify it
+grant pg_read_all_stats to anon;
+ERROR:  "anon" is a reserved role, only superusers can modify it
+\echo
+
+-- cannnot revoke memberships from reserved-roles
+revoke pg_monitor from anon;
+ERROR:  "anon" is a reserved role, only superusers can modify it
+revoke pg_read_all_settings from anon;
+ERROR:  "anon" is a reserved role, only superusers can modify it
+revoke pg_read_all_stats from anon;
+ERROR:  "anon" is a reserved role, only superusers can modify it
+\echo
+
 -- cannot bypass alter-options check by using current_user
 set role anon;
 alter role current_user password 'pass';

--- a/test/sql/reserved_memberships.sql
+++ b/test/sql/reserved_memberships.sql
@@ -16,9 +16,9 @@ create role role_with_reserved_membership admin anon;
 \echo
 
 -- can grant non-reserved memberships
-grant pg_monitor to anon;
-grant pg_read_all_settings to anon;
-grant pg_read_all_stats to anon;
+grant pg_monitor to fake;
+grant pg_read_all_settings to fake;
+grant pg_read_all_stats to fake;
 \echo
 
 -- can grant non-reserved memberships when creating a role

--- a/test/sql/reserved_roles.sql
+++ b/test/sql/reserved_roles.sql
@@ -47,6 +47,18 @@ drop role new_fake;
 create role non_reserved;
 \echo
 
+-- cannnot grant memberships to reserved-roles
+grant pg_monitor to anon;
+grant pg_read_all_settings to anon;
+grant pg_read_all_stats to anon;
+\echo
+
+-- cannnot revoke memberships from reserved-roles
+revoke pg_monitor from anon;
+revoke pg_read_all_settings from anon;
+revoke pg_read_all_stats from anon;
+\echo
+
 -- cannot bypass alter-options check by using current_user
 set role anon;
 alter role current_user password 'pass';


### PR DESCRIPTION
I think it is better reserved-role cannot be modified by using grant or revoke.
So I changed source code to that way.
Do you think?