### PR TITLE
Hotfix invalid guc parameter

### DIFF
--- a/src/supautils.c
+++ b/src/supautils.c
@@ -80,6 +80,8 @@ _PG_init(void)
 								NULL,
 								PGC_SIGHUP, 0,
 								NULL, NULL, NULL);
+
+	EmitWarningsOnPlaceholders("supautils");
 }
 
 /*


### PR DESCRIPTION
Hi!

I fixed supautils.c to prevent invalid parameters from being set.
1. If supautils.xxx is set, supautils emits warnig.
2. If supautils.reserved_roles ='a,b,c,,,' is set, PostgreSQL is shut down when we execute pg_ctl start/restart/reload.

Without the above features, we will not be able to notice if we have made wrong settings until we execute CREATE ROLE/GRANT/REVOKE.