### PR TITLE
Hotfix fail make installcheck

### DIFF
--- a/src/supautils.c
+++ b/src/supautils.c
@@ -1,4 +1,5 @@
 #include "postgres.h"
+#include "access/xact.h"
 #include "tcop/utility.h"
 #include "miscadmin.h"
 #include "utils/varlena.h"
@@ -137,7 +138,7 @@ supautils_hook(PlannedStmt *pstmt,
 	Node   *utility_stmt = pstmt->utilityStmt;
 
 	// Check reserved objects if not a superuser
-	if (!superuser())
+	if (IsTransactionState() && !superuser())
 	{
 
 		// Check if supautils.reserved_memberships is not empty

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -1,11 +1,12 @@
 #include "postgres.h"
+
 #include "access/xact.h"
-#include "tcop/utility.h"
 #include "miscadmin.h"
-#include "utils/varlena.h"
+#include "tcop/utility.h"
 #include "utils/acl.h"
 #include "utils/guc.h"
 #include "utils/guc_tables.h"
+#include "utils/varlena.h"
 
 #define PG13_GTE (PG_VERSION_NUM >= 130000)
 #define PG14_GTE (PG_VERSION_NUM >= 140000)


### PR DESCRIPTION
Hi!

When I executed `make installcheck` with the following settings, the regression test failed.
```
shared_preload_libraries='supautils'
supautils.reserved_roles='aaa'
supautils.reserved_memberships='bbb'
```
The reason is that executing superuser() within an invalid transaction will result in an assertion error.
So, I fixed it.

Regards