### PR TITLE
Add the ability to restrict placeholders' values

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -12,7 +12,7 @@ let
       installPhase = ''
         mkdir -p $out/bin
         install -D supautils.so -t $out/lib
-        
+
         # Build stdlib
         ./bin/build_stdlib.sh
 
@@ -36,14 +36,15 @@ let
 
       PGTZ=UTC initdb --no-locale --encoding=UTF8 --nosync -U "$PGUSER"
 
-      options="-F -c listen_addresses=\"\" -k $PGDATA"
+      options="-F -c listen_addresses=\"\" -k $PGDATA -c shared_preload_libraries=\"supautils\""
 
       reserved_roles="supabase_storage_admin, anon, reserved_but_not_yet_created"
       reserved_memberships="pg_read_server_files, pg_write_server_files, pg_execute_server_program, role_with_reserved_membership"
 
-      ext_options="-c shared_preload_libraries=\"supautils\" -c supautils.reserved_roles=\"$reserved_roles\" -c supautils.reserved_memberships=\"$reserved_memberships\""
+      reserved_stuff_options="-c supautils.reserved_roles=\"$reserved_roles\" -c supautils.reserved_memberships=\"$reserved_memberships\""
+      placeholder_stuff_options="-c supautils.placeholders=\"response.headers, another.placeholder\" -c supautils.placeholders_disallowed_values=\"content-type, x-special-header, special-value\""
 
-      pg_ctl start -o "$options" -o "$ext_options"
+      pg_ctl start -o "$options" -o "$reserved_stuff_options" -o "$placeholder_stuff_options"
 
       createdb contrib_regression
 

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -36,12 +36,12 @@
 /* required macro for extension libraries to work */
 PG_MODULE_MAGIC;
 
-static char *reserved_roles					= NULL;
-static char *reserved_memberships			= NULL;
-static char *placeholders			= NULL;
-static char *placeholders_disallowed_values			= NULL;
-static char *empty_placeholder = NULL;
-static ProcessUtility_hook_type prev_hook	= NULL;
+static char *reserved_roles                  = NULL;
+static char *reserved_memberships            = NULL;
+static char *placeholders                    = NULL;
+static char *placeholders_disallowed_values  = NULL;
+static char *empty_placeholder               = NULL;
+static ProcessUtility_hook_type prev_hook    = NULL;
 
 void _PG_init(void);
 void _PG_fini(void);

--- a/test/expected/restricted_placeholders.out
+++ b/test/expected/restricted_placeholders.out
@@ -1,0 +1,17 @@
+-- placeholder non-restricted values pass
+select set_config('response.headers', '[{"Cache-Control": "public"}, {"Cache-Control": "max-age=259200"}]', true);
+                             set_config                             
+--------------------------------------------------------------------
+ [{"Cache-Control": "public"}, {"Cache-Control": "max-age=259200"}]
+(1 row)
+
+-- placeholder restricted values fail on a set_config
+select set_config('response.headers', '[{"Content-Type": "application/vnd.my.malicious.type"}, {"Cache-Control": "public"}]', true);
+ERROR:  The placeholder contains the "content-type" disallowed value
+select set_config('response.headers', '[{"X-Special-Header": "a-value"}]', true);
+ERROR:  The placeholder contains the "x-special-header" disallowed value
+\echo
+
+-- placeholder restricted values fail on a SET
+set another.placeholder to 'special-value';
+ERROR:  The placeholder contains the "special-value" disallowed value

--- a/test/sql/restricted_placeholders.sql
+++ b/test/sql/restricted_placeholders.sql
@@ -1,0 +1,10 @@
+-- placeholder non-restricted values pass
+select set_config('response.headers', '[{"Cache-Control": "public"}, {"Cache-Control": "max-age=259200"}]', true);
+
+-- placeholder restricted values fail on a set_config
+select set_config('response.headers', '[{"Content-Type": "application/vnd.my.malicious.type"}, {"Cache-Control": "public"}]', true);
+select set_config('response.headers', '[{"X-Special-Header": "a-value"}]', true);
+\echo
+
+-- placeholder restricted values fail on a SET
+set another.placeholder to 'special-value';


### PR DESCRIPTION
Allow restricting placeholders values used by other services.

In particular, PostgREST can set the [response.headers placeholder](https://postgrest.org/en/stable/api.html#setting-response-headers) to add headers to an HTTP response. Certain headers can be disallowed like:

```sql
supautils.placeholders="response.headers, another.placeholder"
supautils.placeholders_disallowed_values="content-type,cache-control"

SELECT set_config('response.headers',  '{"Content-Type": "application/vnd.my.malicious.type"}]', true);
-- ERROR:  22023: The placeholder contains the "content-type" disallowed value
```

### Limitations

The `placeholders_disallowed_values` will be applied to all `placeholders`. We cannot map different disallowed values to different placeholders due to restrictions in the postgres C API.  The [GucStringCheckHook](https://docs.huihoo.com/doxygen/postgresql/guc_8h.html#ac75870e15afd96a6c0a21f65c7c3e7f9) signature doesn't allow passing other data to the hook(`void **extra` is for passing extra info between hooks, from the check hook to the assign hook).