### PR TITLE
feat: `privileged_role`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v13
       with:
         nix_path: nixpkgs=channel:nixos-unstable

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ EXTENSION = supautils
 DATA = $(wildcard sql/*--*.sql)
 
 MODULE_big = supautils
-OBJS = src/supautils.o src/privileged_extensions.o
+OBJS = src/supautils.o src/privileged_extensions.o src/utils.o
 
 TESTS = $(wildcard test/sql/*.sql test/sql/stdlib/array/*.sql test/sql/stdlib/inspect/*.sql)
 REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))

--- a/shell.nix
+++ b/shell.nix
@@ -43,8 +43,9 @@ let
       privileged_extensions="hstore"
       privileged_extensions_custom_scripts_path="$tmpdir/privileged_extensions_custom_scripts"
       privileged_role="privileged_role"
+      privileged_role_allowed_configs="session_replication_role"
 
-      reserved_stuff_options="-c supautils.reserved_roles=\"$reserved_roles\" -c supautils.reserved_memberships=\"$reserved_memberships\" -c supautils.privileged_extensions=\"$privileged_extensions\" -c supautils.privileged_extensions_custom_scripts_path=\"$privileged_extensions_custom_scripts_path\" -c supautils.privileged_role=\"$privileged_role\""
+      reserved_stuff_options="-c supautils.reserved_roles=\"$reserved_roles\" -c supautils.reserved_memberships=\"$reserved_memberships\" -c supautils.privileged_extensions=\"$privileged_extensions\" -c supautils.privileged_extensions_custom_scripts_path=\"$privileged_extensions_custom_scripts_path\" -c supautils.privileged_role=\"$privileged_role\" -c supautils.privileged_role_allowed_configs=\"$privileged_role_allowed_configs\""
       placeholder_stuff_options='-c supautils.placeholders="response.headers, another.placeholder" -c supautils.placeholders_disallowed_values="\"content-type\",\"x-special-header\",special-value"'
 
       pg_ctl start -o "$options" -o "$reserved_stuff_options" -o "$placeholder_stuff_options"

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 with import (builtins.fetchTarball {
-  name = "2022-10-14";
-  url = "https://github.com/NixOS/nixpkgs/archive/cc090d2b942f76fad83faf6e9c5ed44b73ba7114.tar.gz";
-  sha256 = "0a1wwpbn2f38pcays6acq1gz19vw4jadl8yd3i3cd961f1x2vdq2";
+  name = "2022-10-25";
+  url = "https://github.com/NixOS/nixpkgs/archive/a11f8032aa9de58be11190b71320f98f9a3c395b.tar.gz";
+  sha256 = "101y90kqqfqc5vkigw5rbcqw01cg9nndknz4q4gb28zi4918r1hz";
 }) {};
 let
   supautils = { postgresql }:

--- a/shell.nix
+++ b/shell.nix
@@ -42,8 +42,9 @@ let
       reserved_memberships="pg_read_server_files, pg_write_server_files, pg_execute_server_program, role_with_reserved_membership"
       privileged_extensions="hstore"
       privileged_extensions_custom_scripts_path="$tmpdir/privileged_extensions_custom_scripts"
+      privileged_role="privileged_role"
 
-      reserved_stuff_options="-c supautils.reserved_roles=\"$reserved_roles\" -c supautils.reserved_memberships=\"$reserved_memberships\" -c supautils.privileged_extensions=\"$privileged_extensions\" -c supautils.privileged_extensions_custom_scripts_path=\"$privileged_extensions_custom_scripts_path\""
+      reserved_stuff_options="-c supautils.reserved_roles=\"$reserved_roles\" -c supautils.reserved_memberships=\"$reserved_memberships\" -c supautils.privileged_extensions=\"$privileged_extensions\" -c supautils.privileged_extensions_custom_scripts_path=\"$privileged_extensions_custom_scripts_path\" -c supautils.privileged_role=\"$privileged_role\""
       placeholder_stuff_options='-c supautils.placeholders="response.headers, another.placeholder" -c supautils.placeholders_disallowed_values="\"content-type\",\"x-special-header\",special-value"'
 
       pg_ctl start -o "$options" -o "$reserved_stuff_options" -o "$placeholder_stuff_options"

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -279,7 +279,7 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 
 				run_process_utility_hook(prev_hook);
 
-				alter_role_with_bypassrls_option_as_superuser(stmt->role->rolename, bypassrls_option);
+				alter_role_with_bypassrls_option_as_superuser(stmt->role->rolename, bypassrls_option, privileged_extensions_superuser);
 
 				return;
 			}
@@ -371,7 +371,7 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 
 						run_process_utility_hook(prev_hook);
 
-						alter_role_with_bypassrls_option_as_superuser(stmt->role, bypassrls_option);
+						alter_role_with_bypassrls_option_as_superuser(stmt->role, bypassrls_option, privileged_extensions_superuser);
 
 						pfree(true_node);
 						pfree(bypassrls_option);
@@ -562,6 +562,10 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 				Oid prev_role_oid;
 				int prev_role_sec_context;
 
+				if (privileged_extensions_superuser != NULL) {
+					superuser_oid = get_role_oid(privileged_extensions_superuser, false);
+				}
+
 				GetUserIdAndSecContext(&prev_role_oid, &prev_role_sec_context);
 				SetUserIdAndSecContext(superuser_oid, prev_role_sec_context |
 									   SECURITY_LOCAL_USERID_CHANGE |
@@ -601,6 +605,10 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 				Oid superuser_oid = BOOTSTRAP_SUPERUSERID;
 				Oid prev_role_oid;
 				int prev_role_sec_context;
+
+				if (privileged_extensions_superuser != NULL) {
+					superuser_oid = get_role_oid(privileged_extensions_superuser, false);
+				}
 
 				GetUserIdAndSecContext(&prev_role_oid, &prev_role_sec_context);
 				SetUserIdAndSecContext(superuser_oid, prev_role_sec_context |

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,13 +1,18 @@
 #include "utils.h"
 
 void alter_role_with_bypassrls_option_as_superuser(const char *role_name,
-                                                   DefElem *bypassrls_option) {
+                                                   DefElem *bypassrls_option,
+                                                   const char *superuser_name) {
     Oid superuser_oid = BOOTSTRAP_SUPERUSERID;
     Oid prev_role_oid = 0;
     int prev_role_sec_context = 0;
 
     RoleSpec *role = makeNode(RoleSpec);
     AlterRoleStmt *bypassrls_stmt = makeNode(AlterRoleStmt);
+
+    if (superuser_name != NULL) {
+        superuser_oid = get_role_oid(superuser_name, false);
+    }
 
     role->roletype = ROLESPEC_CSTRING;
     role->rolename = pstrdup(role_name);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,3 +1,7 @@
+#include <postgres.h>
+
+#include <utils/varlena.h>
+
 #include "utils.h"
 
 void alter_role_with_bypassrls_option_as_superuser(const char *role_name,
@@ -40,4 +44,24 @@ void alter_role_with_bypassrls_option_as_superuser(const char *role_name,
     pfree(bypassrls_stmt);
 
     return;
+}
+
+bool is_string_in_comma_delimited_string(const char *s1, char *s2) {
+    bool s1_is_in_s2 = false;
+    List *split_s2 = NIL;
+    ListCell *lc;
+
+    SplitIdentifierString(s2, ',', &split_s2);
+
+    foreach (lc, split_s2) {
+        char *s2_elem = (char *)lfirst(lc);
+
+        if (strcmp(s1, s2_elem) == 0) {
+            s1_is_in_s2 = true;
+            break;
+        }
+    }
+    list_free(split_s2);
+
+    return s1_is_in_s2;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,38 @@
+#include "utils.h"
+
+void alter_role_with_bypassrls_option_as_superuser(const char *role_name,
+                                                   DefElem *bypassrls_option) {
+    Oid superuser_oid = BOOTSTRAP_SUPERUSERID;
+    Oid prev_role_oid = 0;
+    int prev_role_sec_context = 0;
+
+    RoleSpec *role = makeNode(RoleSpec);
+    AlterRoleStmt *bypassrls_stmt = makeNode(AlterRoleStmt);
+
+    role->roletype = ROLESPEC_CSTRING;
+    role->rolename = pstrdup(role_name);
+    role->location = -1;
+
+    bypassrls_stmt->role = role;
+    bypassrls_stmt->options = list_make1(bypassrls_option);
+
+    GetUserIdAndSecContext(&prev_role_oid, &prev_role_sec_context);
+    SetUserIdAndSecContext(superuser_oid, prev_role_sec_context |
+                                              SECURITY_LOCAL_USERID_CHANGE |
+                                              SECURITY_RESTRICTED_OPERATION);
+
+#if PG15_GTE
+    AlterRole(NULL, bypassrls_stmt);
+#else
+    AlterRole(bypassrls_stmt);
+#endif
+
+    SetUserIdAndSecContext(prev_role_oid, prev_role_sec_context);
+
+    pfree(role->rolename);
+    pfree(role);
+    list_free(bypassrls_stmt->options);
+    pfree(bypassrls_stmt);
+
+    return;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -3,6 +3,9 @@
 
 #include <postgres.h>
 
+#include <catalog/pg_authid.h>
+#include <commands/user.h>
+#include <miscadmin.h>
 #include <nodes/params.h>
 #include <tcop/dest.h>
 #include <tcop/utility.h>
@@ -10,6 +13,7 @@
 
 #define PG13_GTE (PG_VERSION_NUM >= 130000)
 #define PG14_GTE (PG_VERSION_NUM >= 140000)
+#define PG15_GTE (PG_VERSION_NUM >= 150000)
 
 #if PG14_GTE
 
@@ -47,5 +51,9 @@
     } else {                                                                   \
         standard_ProcessUtility(PROCESS_UTILITY_ARGS);                         \
     }
+
+extern void
+alter_role_with_bypassrls_option_as_superuser(const char *role_name,
+                                              DefElem *bypassrls_option);
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -9,6 +9,7 @@
 #include <nodes/params.h>
 #include <tcop/dest.h>
 #include <tcop/utility.h>
+#include <utils/acl.h>
 #include <utils/queryenvironment.h>
 
 #define PG13_GTE (PG_VERSION_NUM >= 130000)
@@ -54,6 +55,7 @@
 
 extern void
 alter_role_with_bypassrls_option_as_superuser(const char *role_name,
-                                              DefElem *bypassrls_option);
+                                              DefElem *bypassrls_option,
+                                              const char *superuser_name);
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -58,4 +58,6 @@ alter_role_with_bypassrls_option_as_superuser(const char *role_name,
                                               DefElem *bypassrls_option,
                                               const char *superuser_name);
 
+extern bool is_string_in_comma_delimited_string(const char *s1, char *s2);
+
 #endif

--- a/test/expected/privileged_role.out
+++ b/test/expected/privileged_role.out
@@ -1,0 +1,103 @@
+-- non-superuser privileged role
+set role privileged_role;
+\echo
+
+-- can set session_replication_role config
+set session_replication_role to 'replica';
+begin;
+  set local session_replication_role to 'origin';
+commit;
+reset session_replication_role;
+\echo
+
+-- non-superuser non-privileged role cannot set session_replication_role config
+set role rolecreator;
+set session_replication_role to 'replica';
+ERROR:  permission denied to set parameter "session_replication_role"
+begin;
+  set local session_replication_role to 'origin';
+ERROR:  permission denied to set parameter "session_replication_role"
+commit;
+reset session_replication_role;
+ERROR:  permission denied to set parameter "session_replication_role"
+set role privileged_role;
+\echo
+
+-- superuser can set session_replication_role config
+set role postgres;
+set session_replication_role to 'replica';
+begin;
+  set local session_replication_role to 'origin';
+commit;
+reset session_replication_role;
+set role privileged_role;
+\echo
+
+-- can manage bypassrls role attribute
+create role r bypassrls;
+select rolbypassrls from pg_roles where rolname = 'r';
+ rolbypassrls 
+--------------
+ t
+(1 row)
+
+alter role r nobypassrls;
+select rolbypassrls from pg_roles where rolname = 'r';
+ rolbypassrls 
+--------------
+ f
+(1 row)
+
+alter role r bypassrls;
+select rolbypassrls from pg_roles where rolname = 'r';
+ rolbypassrls 
+--------------
+ t
+(1 row)
+
+drop role r;
+\echo
+
+-- non-superuser non-privileged role cannot manage bypassrls role attribute
+set role rolecreator;
+-- the error message changed in PG14
+do $$
+begin
+  create role r bypassrls;
+  exception when insufficient_privilege then null;
+end;
+$$ language plpgsql;
+create role r;
+alter role r nobypassrls;
+ERROR:  must be superuser to change bypassrls attribute
+alter role r bypassrls;
+ERROR:  must be superuser to change bypassrls attribute
+drop role r;
+set role privileged_role;
+\echo
+
+-- superuser can manage bypassrls role attribute
+set role postgres;
+create role r bypassrls;
+select rolbypassrls from pg_roles where rolname = 'r';
+ rolbypassrls 
+--------------
+ t
+(1 row)
+
+alter role r nobypassrls;
+select rolbypassrls from pg_roles where rolname = 'r';
+ rolbypassrls 
+--------------
+ f
+(1 row)
+
+alter role r bypassrls;
+select rolbypassrls from pg_roles where rolname = 'r';
+ rolbypassrls 
+--------------
+ t
+(1 row)
+
+drop role r;
+set role privileged_role;

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -9,6 +9,7 @@ grant supabase_storage_admin to rolecreator;
 
 -- other roles
 create role fake noinherit;
+create role privileged_role login;
 
 -- create extension
 create schema supa;

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -9,7 +9,7 @@ grant supabase_storage_admin to rolecreator;
 
 -- other roles
 create role fake noinherit;
-create role privileged_role login;
+create role privileged_role login createrole;
 
 -- create extension
 create schema supa;

--- a/test/sql/privileged_role.sql
+++ b/test/sql/privileged_role.sql
@@ -1,0 +1,77 @@
+-- non-superuser privileged role
+set role privileged_role;
+\echo
+
+-- can set session_replication_role config
+set session_replication_role to 'replica';
+begin;
+  set local session_replication_role to 'origin';
+commit;
+reset session_replication_role;
+\echo
+
+-- non-superuser non-privileged role cannot set session_replication_role config
+set role rolecreator;
+
+set session_replication_role to 'replica';
+begin;
+  set local session_replication_role to 'origin';
+commit;
+reset session_replication_role;
+
+set role privileged_role;
+\echo
+
+-- superuser can set session_replication_role config
+set role postgres;
+
+set session_replication_role to 'replica';
+begin;
+  set local session_replication_role to 'origin';
+commit;
+reset session_replication_role;
+
+set role privileged_role;
+\echo
+
+-- can manage bypassrls role attribute
+create role r bypassrls;
+select rolbypassrls from pg_roles where rolname = 'r';
+alter role r nobypassrls;
+select rolbypassrls from pg_roles where rolname = 'r';
+alter role r bypassrls;
+select rolbypassrls from pg_roles where rolname = 'r';
+drop role r;
+\echo
+
+-- non-superuser non-privileged role cannot manage bypassrls role attribute
+set role rolecreator;
+
+-- the error message changed in PG14
+do $$
+begin
+  create role r bypassrls;
+  exception when insufficient_privilege then null;
+end;
+$$ language plpgsql;
+
+create role r;
+alter role r nobypassrls;
+alter role r bypassrls;
+drop role r;
+
+set role privileged_role;
+\echo
+
+-- superuser can manage bypassrls role attribute
+set role postgres;
+
+create role r bypassrls;
+select rolbypassrls from pg_roles where rolname = 'r';
+alter role r nobypassrls;
+select rolbypassrls from pg_roles where rolname = 'r';
+alter role r bypassrls;
+select rolbypassrls from pg_roles where rolname = 'r';
+drop role r;
+
+set role privileged_role;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

- cannot `comment` on privileged extensions because they are owned by the `privileged_extensions_superuser`
- cannot set `bypassrls` role attribute without being superuser
- cannot `set session_replication_role` without being superuser

## What is the new behavior?

Allow setting a role to be a `privileged_role`, which has additional privileges:
- can `comment` on any extension
- can `{create|alter} role ... [no]bypassrls`
- can `{set [local]|reset} session_replication_role`

Currently, these privileges are not inheritable.