### PR TITLE
Security patch fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pg-version: ['12', '13', '14', '15']
 
     steps:
     - uses: actions/checkout@v3
@@ -13,4 +16,4 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - name: Run tests
-      run: nix-shell --run "supautils-with-pg-12 make installcheck && supautils-with-pg-13 make installcheck && supautils-with-pg-14 make installcheck && supautils-with-pg-15 make installcheck"
+      run: nix-shell --run "supautils-with-pg-${{ matrix.pg-version }} make installcheck"

--- a/shell.nix
+++ b/shell.nix
@@ -21,8 +21,10 @@ let
       '';
     };
   pgWithExt = { postgresql } :
-    let pg = postgresql.withPackages (p: [ (supautils {inherit postgresql;}) ]);
-    in ''
+  let
+    pg = postgresql.withPackages (p: [ (supautils {inherit postgresql;}) ]);
+    ver = builtins.head (builtins.splitVersion postgresql.version);
+    script = ''
       export PATH=${pg}/bin:"$PATH"
 
       tmpdir="$(mktemp -d)"
@@ -60,11 +62,11 @@ let
 
       "$@"
     '';
-  supautils-with-pg-12 = writeShellScriptBin "supautils-with-pg-12" (pgWithExt { postgresql = postgresql_12; });
-  supautils-with-pg-13 = writeShellScriptBin "supautils-with-pg-13" (pgWithExt { postgresql = postgresql_13; });
-  supautils-with-pg-14 = writeShellScriptBin "supautils-with-pg-14" (pgWithExt { postgresql = postgresql_14; });
-  supautils-with-pg-15 = writeShellScriptBin "supautils-with-pg-15" (pgWithExt { postgresql = postgresql_15; });
+  in
+    writeShellScriptBin "supautils-with-pg-${ver}" script;
+  supportedPgVersions = [  postgresql_12 postgresql_13 postgresql_14 postgresql_15 ];
+  extAll = map (x: pgWithExt { postgresql = x;}) supportedPgVersions;
 in
 mkShell {
-  buildInputs = [ supautils-with-pg-12 supautils-with-pg-13 supautils-with-pg-14 supautils-with-pg-15];
+  buildInputs = [ extAll ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -40,12 +40,12 @@ let
 
       options="-F -c listen_addresses=\"\" -k $PGDATA -c shared_preload_libraries=\"supautils\""
 
-      reserved_roles="supabase_storage_admin, anon, reserved_but_not_yet_created"
+      reserved_roles="supabase_storage_admin, anon, reserved_but_not_yet_created, authenticator*"
       reserved_memberships="pg_read_server_files, pg_write_server_files, pg_execute_server_program, role_with_reserved_membership"
       privileged_extensions="hstore, postgres_fdw"
       privileged_extensions_custom_scripts_path="$tmpdir/privileged_extensions_custom_scripts"
       privileged_role="privileged_role"
-      privileged_role_allowed_configs="session_replication_role"
+      privileged_role_allowed_configs="session_replication_role, pgrst.*, other.nested.*"
 
       reserved_stuff_options="-c supautils.reserved_roles=\"$reserved_roles\" -c supautils.reserved_memberships=\"$reserved_memberships\" -c supautils.privileged_extensions=\"$privileged_extensions\" -c supautils.privileged_extensions_custom_scripts_path=\"$privileged_extensions_custom_scripts_path\" -c supautils.privileged_role=\"$privileged_role\" -c supautils.privileged_role_allowed_configs=\"$privileged_role_allowed_configs\""
       placeholder_stuff_options='-c supautils.placeholders="response.headers, another.placeholder" -c supautils.placeholders_disallowed_values="\"content-type\",\"x-special-header\",special-value"'

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -61,7 +61,7 @@ static void
 supautils_hook(PROCESS_UTILITY_PARAMS);
 
 static void
-confirm_reserved_roles(const char *target, bool is_privileged_role);
+confirm_reserved_roles(const char *target, bool allow_configurable_roles);
 
 static void
 confirm_reserved_memberships(const char *target);
@@ -780,7 +780,7 @@ check_parameter(char *val, char *name)
 }
 
 static void
-confirm_reserved_roles(const char *target, bool is_privileged_role)
+confirm_reserved_roles(const char *target, bool allow_configurable_roles)
 {
 	List *reserved_roles_list;
 	ListCell *role;
@@ -793,7 +793,7 @@ confirm_reserved_roles(const char *target, bool is_privileged_role)
 		{
 			char *reserved_role = (char *) lfirst(role);
 			bool is_configurable_role = remove_ending_wildcard(reserved_role);
-			bool should_modify_role = is_configurable_role && is_privileged_role;
+			bool should_modify_role = is_configurable_role && allow_configurable_roles;
 
 			if (strcmp(target, reserved_role) == 0)
 			{

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -61,10 +61,10 @@ static void
 supautils_hook(PROCESS_UTILITY_PARAMS);
 
 static void
-comfirm_reserved_roles(const char *target);
+confirm_reserved_roles(const char *target, bool is_privileged_role);
 
 static void
-comfirm_reserved_memberships(const char *target);
+confirm_reserved_memberships(const char *target);
 
 static bool
 reserved_roles_check_hook(char **newval, void **extra, GucSource source);
@@ -258,7 +258,7 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 					break;
 				}
 
-				comfirm_reserved_roles(get_rolespec_name(stmt->role));
+				confirm_reserved_roles(get_rolespec_name(stmt->role), false);
 
 				if (!has_privileged_role()){
 					break;
@@ -299,6 +299,7 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 		case T_AlterRoleSetStmt:
 			{
 				AlterRoleSetStmt *stmt = (AlterRoleSetStmt *)utility_stmt;
+				bool is_privileged_role = false;
 
 				if (!IsTransactionState()) {
 					break;
@@ -307,7 +308,13 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 					break;
 				}
 
-				comfirm_reserved_roles(get_rolespec_name(stmt->role));
+				is_privileged_role = has_privileged_role();
+
+				confirm_reserved_roles(get_rolespec_name(stmt->role), is_privileged_role);
+
+				if (!is_privileged_role){
+					break;
+				}
 
 				if (privileged_role_allowed_configs == NULL) {
 					break;
@@ -317,10 +324,6 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 					if (!is_privileged_role_allowed_config) {
 						break;
 					}
-				}
-
-				if (!has_privileged_role()){
-					break;
 				}
 
 				{
@@ -356,7 +359,7 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 						break;
 
 					/* CREATE ROLE <reserved_role> */
-					comfirm_reserved_roles(created_role);
+					confirm_reserved_roles(created_role, false);
 
 					// Allow bypassrls attribute if using `privileged_role`.
 					if (!has_privileged_role()){
@@ -392,7 +395,7 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 						foreach(role_cell, addroleto)
 						{
 							RoleSpec *rolemember = lfirst(role_cell);
-							comfirm_reserved_memberships(get_rolespec_name(rolemember));
+							confirm_reserved_memberships(get_rolespec_name(rolemember));
 						}
 					}
 
@@ -403,7 +406,7 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 					 * should already exist, but handle it anyway.
 					 */
 					if (hasrolemembers)
-						comfirm_reserved_memberships(created_role);
+						confirm_reserved_memberships(created_role);
 
 					// CREATE ROLE <any_role> BYPASSRLS
 					//
@@ -451,7 +454,7 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 						if (role->roletype != ROLESPEC_CSTRING)
 							break;
 
-						comfirm_reserved_roles(role->rolename);
+						confirm_reserved_roles(role->rolename, false);
 					}
 				}
 				break;
@@ -467,16 +470,19 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 					GrantRoleStmt *stmt = (GrantRoleStmt *) utility_stmt;
 					ListCell *grantee_role_cell;
 					ListCell *role_cell;
+					bool is_privileged_role = false;
 
-					/* GRANT <role> TO <another_role> */
+					/* GRANT <reserved_role> TO <role> */
 					if (stmt->is_grant)
 					{
 						foreach(role_cell, stmt->granted_roles)
 						{
 							AccessPriv *priv = (AccessPriv *) lfirst(role_cell);
-							comfirm_reserved_memberships(priv->priv_name);
+							confirm_reserved_memberships(priv->priv_name);
 						}
 					}
+
+					is_privileged_role = has_privileged_role();
 
 					/*
 					 * GRANT <role> TO <reserved_roles>
@@ -485,7 +491,8 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 					foreach(grantee_role_cell, stmt->grantee_roles)
 					{
 						AccessPriv *priv = (AccessPriv *) lfirst(grantee_role_cell);
-						comfirm_reserved_roles(priv->priv_name);
+						// privileged_role can do GRANT <role> to <reserved_role>
+						confirm_reserved_roles(priv->priv_name, is_privileged_role);
 					}
 				}
 				break;
@@ -504,8 +511,8 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 					if (stmt->renameType != OBJECT_ROLE)
 						break;
 
-					comfirm_reserved_roles(stmt->subname);
-					comfirm_reserved_roles(stmt->newname);
+					confirm_reserved_roles(stmt->subname, false);
+					confirm_reserved_roles(stmt->newname, false);
 				}
 				break;
 			}
@@ -773,7 +780,7 @@ check_parameter(char *val, char *name)
 }
 
 static void
-comfirm_reserved_roles(const char *target)
+confirm_reserved_roles(const char *target, bool is_privileged_role)
 {
 	List *reserved_roles_list;
 	ListCell *role;
@@ -785,11 +792,17 @@ comfirm_reserved_roles(const char *target)
 		foreach(role, reserved_roles_list)
 		{
 			char *reserved_role = (char *) lfirst(role);
+			bool is_configurable_role = remove_ending_wildcard(reserved_role);
+			bool should_modify_role = is_configurable_role && is_privileged_role;
 
 			if (strcmp(target, reserved_role) == 0)
 			{
-				list_free(reserved_roles_list);
-				EREPORT_RESERVED_ROLE(reserved_role);
+				if(should_modify_role){
+					continue;
+				} else {
+					list_free(reserved_roles_list);
+					EREPORT_RESERVED_ROLE(reserved_role);
+				}
 			}
 		}
 		list_free(reserved_roles_list);
@@ -797,7 +810,7 @@ comfirm_reserved_roles(const char *target)
 }
 
 static void
-comfirm_reserved_memberships(const char *target)
+confirm_reserved_memberships(const char *target)
 {
 	List *reserved_memberships_list;
 	ListCell *membership;

--- a/src/utils.c
+++ b/src/utils.c
@@ -7,7 +7,7 @@
 static Oid prev_role_oid = 0;
 static int prev_role_sec_context = 0;
 
-static bool strstarts(const char*, const char*);
+static bool strstarts(const char *, const char *);
 
 void alter_role_with_bypassrls_option_as_superuser(const char *role_name,
                                                    DefElem *bypassrls_option,
@@ -74,7 +74,8 @@ bool is_string_in_comma_delimited_string(const char *s1, const char *s2) {
     foreach (lc, split_s2) {
         char *s2_elem = (char *)lfirst(lc);
 
-        if ((remove_ending_wildcard(s2_elem) && strstarts(s1, s2_elem)) || strcmp(s1, s2_elem) == 0) {
+        if ((remove_ending_wildcard(s2_elem) && strstarts(s1, s2_elem)) ||
+            strcmp(s1, s2_elem) == 0) {
             s1_is_in_s2 = true;
             break;
         }
@@ -86,22 +87,21 @@ bool is_string_in_comma_delimited_string(const char *s1, const char *s2) {
     return s1_is_in_s2;
 }
 
-bool remove_ending_wildcard(char* elem)
-{
-  bool wildcard_removed = false;
-  if(elem){
-    size_t elem_size = strlen(elem);
+bool remove_ending_wildcard(char *elem) {
+    bool wildcard_removed = false;
+    if (elem) {
+        size_t elem_size = strlen(elem);
 
-    if(elem_size > 1 && elem[elem_size - 1] == '*'){
-      wildcard_removed = true;
-      elem[elem_size - 1] = '\0'; //remove the '*' from the end of the string
+        if (elem_size > 1 && elem[elem_size - 1] == '*') {
+            wildcard_removed = true;
+            elem[elem_size - 1] =
+                '\0'; // remove the '*' from the end of the string
+        }
     }
-  }
 
-  return wildcard_removed;
+    return wildcard_removed;
 }
 
-bool strstarts(const char *str, const char *prefix)
-{
-  return strncmp(str, prefix, strlen(prefix)) == 0;
+bool strstarts(const char *str, const char *prefix) {
+    return strncmp(str, prefix, strlen(prefix)) == 0;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -7,6 +7,8 @@
 static Oid prev_role_oid = 0;
 static int prev_role_sec_context = 0;
 
+static bool strstarts(const char*, const char*);
+
 void alter_role_with_bypassrls_option_as_superuser(const char *role_name,
                                                    DefElem *bypassrls_option,
                                                    const char *superuser_name) {
@@ -72,7 +74,7 @@ bool is_string_in_comma_delimited_string(const char *s1, const char *s2) {
     foreach (lc, split_s2) {
         char *s2_elem = (char *)lfirst(lc);
 
-        if (strcmp(s1, s2_elem) == 0) {
+        if ((remove_ending_wildcard(s2_elem) && strstarts(s1, s2_elem)) || strcmp(s1, s2_elem) == 0) {
             s1_is_in_s2 = true;
             break;
         }
@@ -82,4 +84,24 @@ bool is_string_in_comma_delimited_string(const char *s1, const char *s2) {
     pfree(s2_tmp);
 
     return s1_is_in_s2;
+}
+
+bool remove_ending_wildcard(char* elem)
+{
+  bool wildcard_removed = false;
+  if(elem){
+    size_t elem_size = strlen(elem);
+
+    if(elem_size > 1 && elem[elem_size - 1] == '*'){
+      wildcard_removed = true;
+      elem[elem_size - 1] = '\0'; //remove the '*' from the end of the string
+    }
+  }
+
+  return wildcard_removed;
+}
+
+bool strstarts(const char *str, const char *prefix)
+{
+  return strncmp(str, prefix, strlen(prefix)) == 0;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -75,6 +75,6 @@ extern void switch_to_original_role(void);
  */
 extern bool is_string_in_comma_delimited_string(const char *s1, const char *s2);
 
-extern bool remove_ending_wildcard(char*);
+extern bool remove_ending_wildcard(char *);
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -75,4 +75,6 @@ extern void switch_to_original_role(void);
  */
 extern bool is_string_in_comma_delimited_string(const char *s1, const char *s2);
 
+extern bool remove_ending_wildcard(char*);
+
 #endif

--- a/test/expected/privileged_role.out
+++ b/test/expected/privileged_role.out
@@ -123,3 +123,29 @@ set role privileged_role;
 -- regression: https://github.com/supabase/supautils/issues/34
 create role tmp;
 alter role tmp;
+\echo
+
+-- privileged_role can modify reserved roles GUCs
+set role privileged_role;
+alter role authenticator set search_path to public;
+alter role authenticator set statement_timeout = '15s';
+\echo
+
+-- privileged_role can do GRANT <role> to <reserved_role>
+grant testme to authenticator;
+\echo
+
+-- privileged_role can set wildcard privileged_role_allowed_configs
+alter role authenticator set pgrst.db_plan_enabled to true;
+alter role authenticator set pgrst.db_prepared_statements to false;
+alter role authenticator set other.nested.foo to true;
+alter role authenticator set other.nested.bar to true;
+\echo
+
+-- privileged_role cannot drop, rename or nologin reserved role
+drop role authenticator;
+ERROR:  "authenticator" is a reserved role, only superusers can modify it
+alter role authenticator rename to authorized;
+ERROR:  "authenticator" is a reserved role, only superusers can modify it
+alter role authenticator nologin;
+ERROR:  "authenticator" is a reserved role, only superusers can modify it

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -10,6 +10,8 @@ grant supabase_storage_admin to rolecreator;
 -- other roles
 create role fake noinherit;
 create role privileged_role login createrole;
+create role testme noinherit;
+create role authenticator login noinherit;
 
 -- create extension
 create schema supa;

--- a/test/sql/privileged_role.sql
+++ b/test/sql/privileged_role.sql
@@ -96,3 +96,26 @@ set role privileged_role;
 -- regression: https://github.com/supabase/supautils/issues/34
 create role tmp;
 alter role tmp;
+\echo
+
+-- privileged_role can modify reserved roles GUCs
+set role privileged_role;
+alter role authenticator set search_path to public;
+alter role authenticator set statement_timeout = '15s';
+\echo
+
+-- privileged_role can do GRANT <role> to <reserved_role>
+grant testme to authenticator;
+\echo
+
+-- privileged_role can set wildcard privileged_role_allowed_configs
+alter role authenticator set pgrst.db_plan_enabled to true;
+alter role authenticator set pgrst.db_prepared_statements to false;
+alter role authenticator set other.nested.foo to true;
+alter role authenticator set other.nested.bar to true;
+\echo
+
+-- privileged_role cannot drop, rename or nologin reserved role
+drop role authenticator;
+alter role authenticator rename to authorized;
+alter role authenticator nologin;


### PR DESCRIPTION
Allows using the `supautils.privileged_role` to do:

- `alter role anon set statement_timeout = '15s'` ([ref](https://github.com/supabase/supabase/discussions/9314#discussioncomment-4352758)) - c8efcd7061e062f1b3d46f1f1a41aa48a66f4c68
- `grant testme to authenticator`([ref](https://github.com/supabase/supabase/discussions/9314#discussioncomment-4616722), also affects [custom db roles](https://github.com/supabase/supabase/discussions/11948#discussioncomment-4802137)) - b3a6e95cc070abd3b368e9dd4144e4eae9eff05d

Allows using wildcards on placeholders defined on `privileged_role_allowed_configs = "pgrst.*"`, this solves:

- `alter role authenticator set pgrst.db_plan_enabled to true`([ref](https://github.com/supabase/supabase/discussions/9314#discussioncomment-4469017)) - 146155ec272cc3ca26f70868b3934d8ac1a68daa

Otherwise we'd have to whitelist all possible placeholders.