### PR TITLE
Add .dylib into .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ regression.*
 *.o
 *.so
 *.bc
+*.dylib
 venv/
 site/
 results/*.out


### PR DESCRIPTION
Hi,

When building supautils with PostgreSQL 16dev on my MacOS,
I found that supautils.dylib was created but there was no entry for
.dylib in .gitignore. So, how about adding *.dylib into .gitignore,
like .gitignore in PostgreSQL also has?

Regards,
