### PR TITLE
Fix bug that could cause supautils to lead to segmentation fault.

### DIFF
--- a/src/supautils.c
+++ b/src/supautils.c
@@ -897,10 +897,14 @@ restrict_placeholders_check_hook(char **newval, void **extra, GucSource source)
 	return true;
 }
 
-bool has_privileged_role(void) {
-	Oid role_oid = get_role_oid(privileged_role, true);
-	return
-		privileged_role &&
-		OidIsValid(role_oid) &&
-		GetUserId() == role_oid;
+static bool
+has_privileged_role(void)
+{
+	Oid	role_oid;
+
+	if (privileged_role == NULL)
+		return false;
+
+	role_oid = get_role_oid(privileged_role, true);
+	return OidIsValid(role_oid) && (GetUserId() == role_oid);
 }


### PR DESCRIPTION
With the setting supautils.privileged_role not set, supautils caused a segmentation fault when CREATE ROLE command was executed. ISTM that this happened because supautils_hook() unexpectedly passed "privileged_role" variable to get_role_oid() even though it's NULL. Attached patch fixes this bug.