### PR TITLE
feat: make privilege role inheritable

### DIFF
--- a/test/expected/privileged_role.out
+++ b/test/expected/privileged_role.out
@@ -149,3 +149,10 @@ alter role authenticator rename to authorized;
 ERROR:  "authenticator" is a reserved role, only superusers can modify it
 alter role authenticator nologin;
 ERROR:  "authenticator" is a reserved role, only superusers can modify it
+\echo
+
+-- member of privileged_role can do privileged role stuff
+set role privileged_role_member;
+grant testme to authenticator;
+NOTICE:  role "authenticator" is already a member of role "testme"
+set role privileged_role;

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -10,5 +10,6 @@ grant supabase_storage_admin to rolecreator;
 -- other roles
 create role fake noinherit;
 create role privileged_role login createrole;
+create role privileged_role_member login createrole in role privileged_role;
 create role testme noinherit;
 create role authenticator login noinherit;

--- a/test/sql/privileged_role.sql
+++ b/test/sql/privileged_role.sql
@@ -119,3 +119,11 @@ alter role authenticator set other.nested.bar to true;
 drop role authenticator;
 alter role authenticator rename to authorized;
 alter role authenticator nologin;
+\echo
+
+-- member of privileged_role can do privileged role stuff
+set role privileged_role_member;
+
+grant testme to authenticator;
+
+set role privileged_role;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Only one role can be a privileged role, because the privilege checks use equality (`current_role == supautils.privileged_role`)

## What is the new behavior?

Privilege checks use membership checks (`is_member_of_role(current_role, supautils.privileged_role`), so multiple roles can be privileged
