### PR TITLE
feat: constrained extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 PG_CFLAGS = -Wall -Werror
 
-EXTENSION = supautils
 DATA = $(wildcard sql/*--*.sql)
 
 MODULE_big = supautils

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PG_CFLAGS = -Wall -Werror
 DATA = $(wildcard sql/*--*.sql)
 
 MODULE_big = supautils
-OBJS = src/supautils.o src/privileged_extensions.o src/utils.o
+OBJS = src/supautils.o src/privileged_extensions.o src/constrained_extensions.o src/utils.o
 
 TESTS = $(wildcard test/sql/*.sql)
 REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PG_CFLAGS = -Wall -Werror
+
 EXTENSION = supautils
 DATA = $(wildcard sql/*--*.sql)
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,37 @@ supautils.privileged_extensions_custom_scripts_path = '/opt/postgresql/privilege
 supautils.privileged_extensions_superuser = 'postgres'
 ```
 
+## Constrained Extensions
+
+You can constrain the resources needed for an extension to be installed. This is done through:
+
+```
+supautils.constrained_extensions = '{"plrust": {"cpu": 16, "mem": "1 GB", "disk": "500 MB"}, "any_extension_name": { "mem": "1 GB"}}'
+```
+
+The `supautils.constrained_extensions` is a json object, any other json type will result in an error.
+
+Each top field of the json object corresponds to an extension name, the only value these top fields can take is a json object composed of 3 keys: `cpu`, `mem` and `disk`.
+
+- `cpu`: is the minimum number of cpus this extension needs. It's a json number.
+- `mem`: is the minimum amount of memory this extension needs. It's a json string that takes a human-readable format of bytes.
+- `disk`: is the minimum amount of free disk space this extension needs. It's a json string that takes a human-readable format of bytes.
+  + The free space of the disk is taken from the filesystem where PGDATA (data directory) is located.
+
+Note: this human-readable format is the same that [pg_size_pretty](https://pgpedia.info/p/pg_size_pretty.html) would give.
+
+`CREATE EXTENSION` will fail if any of the resource constraints are not met:
+
+```sql
+create extension plrust;
+
+ERROR:  not enough CPUs for using this extension
+DETAIL:  required CPUs: 16
+HINT:  upgrade to an instance with higher resources
+```
+
+This feature is only available from PostgreSQL 13 onwards.
+
 ## Development
 
 [Nix](https://nixos.org/download.html) is required to set up the environment.

--- a/shell.nix
+++ b/shell.nix
@@ -10,10 +10,8 @@ let
       buildInputs = [ postgresql ];
       src = ./.;
       installPhase = ''
-        mkdir -p $out/bin
+        mkdir -p $out/lib
         install -D supautils.so -t $out/lib
-
-        install -D -t $out/share/postgresql/extension supautils.control
       '';
     };
   pgWithExt = { postgresql } :

--- a/shell.nix
+++ b/shell.nix
@@ -47,7 +47,9 @@ let
       reserved_stuff_options="-c supautils.reserved_roles=\"$reserved_roles\" -c supautils.reserved_memberships=\"$reserved_memberships\" -c supautils.privileged_extensions=\"$privileged_extensions\" -c supautils.privileged_extensions_custom_scripts_path=\"$privileged_extensions_custom_scripts_path\" -c supautils.privileged_role=\"$privileged_role\" -c supautils.privileged_role_allowed_configs=\"$privileged_role_allowed_configs\""
       placeholder_stuff_options='-c supautils.placeholders="response.headers, another.placeholder" -c supautils.placeholders_disallowed_values="\"content-type\",\"x-special-header\",special-value"'
 
-      pg_ctl start -o "$options" -o "$reserved_stuff_options" -o "$placeholder_stuff_options"
+      cexts_option='-c supautils.constrained_extensions="{\"adminpack\": { \"cpu\": 64}, \"cube\": { \"mem\": \"17 GB\"}, \"lo\": { \"disk\": \"20 GB\"}, \"amcheck\": { \"cpu\": 2, \"mem\": \"100 MB\", \"disk\": \"100 MB\"}}"'
+
+      pg_ctl start -o "$options" -o "$reserved_stuff_options" -o "$placeholder_stuff_options" -o "$cexts_option"
 
       mkdir -p "$tmpdir/privileged_extensions_custom_scripts/hstore"
       echo "do \$\$
@@ -70,7 +72,12 @@ let
     '';
   in
     writeShellScriptBin "supautils-with-pg-${ver}" script;
-  supportedPgVersions = [  postgresql_12 postgresql_13 postgresql_14 postgresql_15 ];
+    supportedPgVersions = [
+      postgresql_12
+      postgresql_13
+      postgresql_14
+      postgresql_15
+    ];
   extAll = map (x: pgWithExt { postgresql = x;}) supportedPgVersions;
 in
 mkShell {

--- a/src/constrained_extensions.c
+++ b/src/constrained_extensions.c
@@ -1,0 +1,231 @@
+#include "utils.h"
+
+#if PG13_GTE
+
+#include <postgres.h>
+#include <utils/json.h>
+#include <utils/jsonb.h>
+#include <utils/jsonfuncs.h>
+#include <common/jsonapi.h>
+#include <utils/memutils.h>
+#include <miscadmin.h>
+#include <tsearch/ts_locale.h>
+#include <utils/builtins.h>
+#include <utils/memutils.h>
+
+#include <sys/sysinfo.h>
+#include <sys/statvfs.h>
+#include <errno.h>
+
+#include "constrained_extensions.h"
+
+static void
+json_array_start(void *state)
+{
+	json_constrained_extension_parse_state *parse = state;
+
+	parse->state = JCE_UNEXPECTED_ARRAY;
+	parse->error_msg = "unexpected array";
+}
+
+static void
+json_object_start(void *state)
+{
+	json_constrained_extension_parse_state *parse = state;
+
+	switch (parse->state)
+	{
+		case JCE_EXPECT_TOPLEVEL_START:
+			parse->state = JCE_EXPECT_TOPLEVEL_FIELD;
+			break;
+		case JCE_EXPECT_CPU:
+		case JCE_EXPECT_MEM:
+		case JCE_EXPECT_DISK:
+			parse->error_msg = "unexpected object for cpu, mem or disk, expected a value";
+			parse->state = JCE_UNEXPECTED_OBJECT;
+			break;
+		default:
+			break;
+	}
+}
+
+static void
+json_object_end(void *state)
+{
+	json_constrained_extension_parse_state *parse = state;
+
+	switch (parse->state)
+	{
+		case JCE_EXPECT_CONSTRAINTS_START:
+			parse->state = JCE_EXPECT_TOPLEVEL_FIELD;
+			(parse->total_cexts)++;
+			break;
+		default:
+			break;
+	}
+}
+
+static void
+json_object_field_start(void *state, char *fname, bool isnull)
+{
+	json_constrained_extension_parse_state *parse = state;
+	constrained_extension *x = &parse->cexts[parse->total_cexts];
+
+	switch (parse->state)
+	{
+		case JCE_EXPECT_TOPLEVEL_FIELD:
+			x->name = MemoryContextStrdup(TopMemoryContext, fname);
+			parse->state = JCE_EXPECT_CONSTRAINTS_START;
+			break;
+
+		case JCE_EXPECT_CONSTRAINTS_START:
+			if (strcmp(fname, "cpu") == 0)
+				parse->state = JCE_EXPECT_CPU;
+			else if (strcmp(fname, "mem") == 0)
+				parse->state = JCE_EXPECT_MEM;
+			else if (strcmp(fname, "disk") == 0)
+				parse->state = JCE_EXPECT_DISK;
+			else {
+				parse->state = JCE_UNEXPECTED_FIELD;
+				parse->error_msg = "unexpected field, only cpu, mem or disk are allowed";
+			}
+			break;
+
+		default:
+			break;
+	}
+}
+
+static void
+json_scalar(void *state, char *token, JsonTokenType tokentype)
+{
+	json_constrained_extension_parse_state *parse = state;
+	constrained_extension *x = &parse->cexts[parse->total_cexts];
+
+	switch (parse->state)
+	{
+		case JCE_EXPECT_CPU:
+			if(tokentype == JSON_TOKEN_NUMBER){
+				x->cpu = atoi(token);
+				parse->state = JCE_EXPECT_CONSTRAINTS_START;
+			} else {
+				parse->state = JCE_UNEXPECTED_CPU_VALUE;
+				parse->error_msg = "unexpected cpu value, expected a number";
+			}
+			break;
+
+		case JCE_EXPECT_MEM:
+			if(tokentype == JSON_TOKEN_STRING){
+				x->mem = DatumGetInt64(DirectFunctionCall1(pg_size_bytes, CStringGetTextDatum(token)));
+				parse->state = JCE_EXPECT_CONSTRAINTS_START;
+			} else {
+				parse->state = JCE_UNEXPECTED_MEM_VALUE;
+				parse->error_msg = "unexpected mem value, expected a string with bytes in human-readable format (as returned by pg_size_pretty)";
+			}
+			break;
+
+		case JCE_EXPECT_DISK:
+			if(tokentype == JSON_TOKEN_STRING){
+				x->disk = DatumGetInt64(DirectFunctionCall1(pg_size_bytes, CStringGetTextDatum(token)));
+				parse->state = JCE_EXPECT_CONSTRAINTS_START;
+			} else {
+				parse->state = JCE_UNEXPECTED_DISK_VALUE;
+				parse->error_msg = "unexpected disk value, expected a string with bytes in human-readable format (as returned by pg_size_pretty)";
+			}
+			break;
+
+		case JCE_EXPECT_TOPLEVEL_START:
+			parse->state = JCE_UNEXPECTED_SCALAR;
+			parse->error_msg = "unexpected scalar, expected an object";
+			break;
+
+		default:
+			break;
+	}
+}
+
+json_constrained_extension_parse_state
+parse_constrained_extensions(
+	const char *str,
+	constrained_extension *cexts
+){
+	JsonLexContext *lex;
+	JsonParseErrorType json_error;
+	JsonSemAction sem;
+
+	json_constrained_extension_parse_state state = {JCE_EXPECT_TOPLEVEL_START, NULL, 0, cexts};
+
+	lex = makeJsonLexContextCstringLen(pstrdup(str), strlen(str), PG_UTF8, true);
+
+	sem.semstate = &state;
+	sem.object_start = json_object_start;
+	sem.object_end = json_object_end;
+	sem.array_start = json_array_start;
+	sem.array_end = NULL;
+	sem.object_field_start = json_object_field_start;
+	sem.object_field_end = NULL;
+	sem.array_element_start = NULL;
+	sem.array_element_end = NULL;
+	sem.scalar = json_scalar;
+
+	json_error = pg_parse_json(lex, &sem);
+
+	if (json_error != JSON_SUCCESS)
+		state.error_msg = "invalid json";
+
+	return state;
+}
+
+#define ERROR_HINT "upgrade to an instance with higher resources"
+
+// implementation is Linux specific
+// * the CPUs obtained is the equivalent of `lscpu | grep 'CPU(s)'`
+// * the memory obtained is the equivalent of the total on `free -b`
+// * the disk obtained is the equivalent of the available on `df -B1`
+void constrain_extension(
+	const char* name,
+	constrained_extension *cexts,
+	const size_t total_cexts
+){
+	struct sysinfo info = {};
+	struct statvfs fsdata = {};
+
+	if(sysinfo(&info) < 0){
+		int save_errno = errno;
+		ereport(ERROR, errmsg("sysinfo call failed: %s", strerror(save_errno)));
+	}
+
+	if (statvfs(DataDir, &fsdata) < 0){
+		int save_errno = errno;
+		ereport(ERROR, errmsg("statvfs call failed: %s", strerror(save_errno)));
+	}
+
+	for(size_t i = 0; i < total_cexts; i++){
+		if (strcmp(name, cexts[i].name) == 0) {
+			if(cexts[i].cpu != 0 && cexts[i].cpu > get_nprocs())
+				ereport(ERROR,
+					errdetail("required CPUs: %zu", cexts[i].cpu),
+					errhint(ERROR_HINT),
+					errmsg("not enough CPUs for using this extension")
+				);
+			if(cexts[i].mem != 0 && cexts[i].mem > info.totalram){
+				char *pretty_size = text_to_cstring(DatumGetTextPP(DirectFunctionCall1(pg_size_pretty, Int64GetDatum(cexts[i].mem))));
+				ereport(ERROR,
+					errdetail("required memory: %s", pretty_size),
+					errhint(ERROR_HINT),
+					errmsg("not enough memory for using this extension")
+				);
+			}
+			if(cexts[i].disk != 0 && cexts[i].disk > fsdata.f_bfree * fsdata.f_bsize){
+				char *pretty_size = text_to_cstring(DatumGetTextPP(DirectFunctionCall1(pg_size_pretty, Int64GetDatum(cexts[i].disk))));
+				ereport(ERROR,
+					errdetail("required free disk space: %s", pretty_size),
+					errhint(ERROR_HINT),
+					errmsg("not enough free disk space for using this extension")
+				);
+			}
+		}
+	}
+}
+
+#endif

--- a/src/constrained_extensions.h
+++ b/src/constrained_extensions.h
@@ -1,0 +1,50 @@
+#ifndef CONSTRAINED_EXTENSIONS_H
+#define CONSTRAINED_EXTENSIONS_H
+
+#include <postgres.h>
+
+typedef struct
+{
+	char *name;
+	size_t cpu;
+	int64 mem;
+	int64 disk;
+} constrained_extension;
+
+typedef enum
+{
+	JCE_EXPECT_TOPLEVEL_START,
+	JCE_EXPECT_TOPLEVEL_FIELD,
+	JCE_EXPECT_CONSTRAINTS_START,
+	JCE_EXPECT_CPU,
+	JCE_EXPECT_MEM,
+	JCE_EXPECT_DISK,
+	JCE_UNEXPECTED_FIELD,
+	JCE_UNEXPECTED_ARRAY,
+	JCE_UNEXPECTED_SCALAR,
+	JCE_UNEXPECTED_OBJECT,
+	JCE_UNEXPECTED_CPU_VALUE,
+	JCE_UNEXPECTED_MEM_VALUE,
+	JCE_UNEXPECTED_DISK_VALUE
+} json_constrained_extension_semantic_state;
+
+typedef struct
+{
+	json_constrained_extension_semantic_state state;
+	char* error_msg;
+	int total_cexts;
+	constrained_extension *cexts;
+} json_constrained_extension_parse_state;
+
+extern json_constrained_extension_parse_state
+parse_constrained_extensions(
+	const char *str,
+	constrained_extension *cexts
+);
+
+void constrain_extension(
+	const char* name,
+	constrained_extension *cexts,
+	const size_t total_cexts);
+
+#endif

--- a/supautils.control
+++ b/supautils.control
@@ -1,3 +1,0 @@
-comment = 'Supabase standard library'
-default_version = '0.1.0'
-relocatable = false

--- a/test/expected/constrained_extensions.out
+++ b/test/expected/constrained_extensions.out
@@ -1,0 +1,34 @@
+-- this feature is only enabled for pg >= 13, for pg12 this will be false
+SELECT current_setting('server_version_num')::int >= 130000 as gte_pg13;
+ gte_pg13 
+----------
+ t
+(1 row)
+
+-- constrained by cpu
+create extension adminpack;
+ERROR:  not enough CPUs for using this extension
+DETAIL:  required CPUs: 64
+HINT:  upgrade to an instance with higher resources
+\echo
+
+-- constrained by memory
+create extension cube;
+ERROR:  not enough memory for using this extension
+DETAIL:  required memory: 17 GB
+HINT:  upgrade to an instance with higher resources
+\echo
+
+-- constrained by disk
+create extension lo;
+ERROR:  not enough free disk space for using this extension
+DETAIL:  required free disk space: 20 GB
+HINT:  upgrade to an instance with higher resources
+\echo
+
+-- passes all resource constraints
+create extension amcheck;
+\echo
+
+-- no resource constraints
+create extension bloom;

--- a/test/expected/constrained_extensions_1.out
+++ b/test/expected/constrained_extensions_1.out
@@ -1,0 +1,25 @@
+-- this feature is only enabled for pg >= 13, for pg12 this will be false
+SELECT current_setting('server_version_num')::int >= 130000 as gte_pg13;
+ gte_pg13 
+----------
+ f
+(1 row)
+
+-- constrained by cpu
+create extension adminpack;
+\echo
+
+-- constrained by memory
+create extension cube;
+\echo
+
+-- constrained by disk
+create extension lo;
+\echo
+
+-- passes all resource constraints
+create extension amcheck;
+\echo
+
+-- no resource constraints
+create extension bloom;

--- a/test/sql/constrained_extensions.sql
+++ b/test/sql/constrained_extensions.sql
@@ -1,0 +1,21 @@
+-- this feature is only enabled for pg >= 13, for pg12 this will be false
+SELECT current_setting('server_version_num')::int >= 130000 as gte_pg13;
+
+-- constrained by cpu
+create extension adminpack;
+\echo
+
+-- constrained by memory
+create extension cube;
+\echo
+
+-- constrained by disk
+create extension lo;
+\echo
+
+-- passes all resource constraints
+create extension amcheck;
+\echo
+
+-- no resource constraints
+create extension bloom;


### PR DESCRIPTION
[Rendered documentation](https://github.com/steve-chavez/supautils/blob/constrained-exts/README.md#constrained-extensions)

Define a setting:

```sql
supautils.constrained_extensions = '{"plrust": {"cpu": 16, "mem": "1GB", "disk": "500MB"}, {"anotherone": { "cpu":64}}'
```

And extensions that don't comply the minimum resources will fail:

```sql
create extension plrust;
ERROR:  not enough resources for using this extension
```

## Tasks

- [x] Use pg_parse_json for the config
- [x] Constrain based on CPU
- [x] Constrain based on MEM
- [x] Constrain based on DISK
- [x] Conditionally enable the feature for pg 12 (doesn't support pg JSON API)