### PR TITLE
feat: global before-create extension custom script

### DIFF
--- a/nix/pg_tle.nix
+++ b/nix/pg_tle.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, postgresql, flex }:
+
+stdenv.mkDerivation rec {
+  pname = "pg_tle";
+  version = "1.0.4";
+
+  nativeBuildInputs = [ flex ];
+  buildInputs = [ postgresql ];
+
+  src = fetchFromGitHub {
+    owner  = "aws";
+    repo   = pname;
+    rev    = "refs/tags/v${version}";
+    hash   = "sha256-W/7pLy/27VatCdzUh1NZ4K2FRMD1erfHiFV2eY2x2W0=";
+  };
+
+  makeFlags = [ "FLEX=flex" ];
+
+  installPhase = ''
+    mkdir -p $out/{lib,share/postgresql/extension}
+
+    cp *.so      $out/lib
+    cp *.sql     $out/share/postgresql/extension
+    cp *.control $out/share/postgresql/extension
+  '';
+}

--- a/test/expected/privileged_extensions.out
+++ b/test/expected/privileged_extensions.out
@@ -1,5 +1,6 @@
 -- non-superuser extensions role
 create role extensions_role login;
+grant all on database postgres to extensions_role;
 alter default privileges for role postgres in schema public grant all on tables to extensions_role;
 set role extensions_role;
 \echo
@@ -15,7 +16,7 @@ select '1=>2'::hstore;
 drop extension hstore;
 \echo
 
--- custom scripts are run
+-- per-extension custom scripts are run
 select * from t2;
  column1 
 ---------
@@ -25,6 +26,26 @@ select * from t2;
 reset role;
 drop table t2;
 set role extensions_role;
+\echo
+
+-- global extension custom scripts are run
+create extension pg_tle;
+reset role;
+grant pgtle_admin to extensions_role;
+set role extensions_role;
+select pgtle.install_extension('foo', '1', '', 'select 1', '{}');
+ install_extension 
+-------------------
+ t
+(1 row)
+
+create extension foo cascade;
+NOTICE:  extname: foo, extschema: <NULL>, extversion: <NULL>, extcascade: t
+drop extension pg_tle cascade;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to function pgtle."foo.control"()
+drop cascades to function pgtle."foo--1.sql"()
+drop cascades to extension foo
 \echo
 
 -- custom scripts are run even for superusers

--- a/test/sql/privileged_extensions.sql
+++ b/test/sql/privileged_extensions.sql
@@ -1,5 +1,6 @@
 -- non-superuser extensions role
 create role extensions_role login;
+grant all on database postgres to extensions_role;
 alter default privileges for role postgres in schema public grant all on tables to extensions_role;
 set role extensions_role;
 \echo
@@ -11,12 +12,23 @@ select '1=>2'::hstore;
 drop extension hstore;
 \echo
 
--- custom scripts are run
+-- per-extension custom scripts are run
 select * from t2;
 
 reset role;
 drop table t2;
 set role extensions_role;
+\echo
+
+-- global extension custom scripts are run
+create extension pg_tle;
+reset role;
+grant pgtle_admin to extensions_role;
+set role extensions_role;
+select pgtle.install_extension('foo', '1', '', 'select 1', '{}');
+create extension foo cascade;
+
+drop extension pg_tle cascade;
 \echo
 
 -- custom scripts are run even for superusers


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Only per-extension `before-create` & `after-create` custom scripts are supported

## What is the new behavior?

Support global `before-create` custom script. Execution order is:
- `before-create.sql`
- `$ext/before-create.sql`
- `CREATE EXTENSION`
- `$ext/after-create.sql`

Also support interpolating `@extname`, `@extschema@`, `@extversion@`, `@extcascade@` in extension custom scripts.

## Additional context

This is needed for cascade-creating TLEs that require privileged extensions, e.g.:

```sql
select pgtle.install_extension('foo', '1', '', 'select 1', array['vector']);
create extension foo cascade;
```

In this case we can use something like this as `before-create.sql`:

<details>

<summary>before-create.sql</summary>

```sql
-- Suppress NOTICEs along the lines of "extension already exists"
set client_min_messages = warning;
set log_min_messages = warning;

do $$
declare
  _extname text := @extname@;
  _extschema text := @extschema@;
  _extversion text := @extversion@;
  _extcascade bool := @extcascade@;
  _r record;
begin
  if not _extcascade then
    return;
  end if;

  if not exists (select from pg_extension where extname = 'pg_tle') then
    return;
  end if;

  if not exists (select from pgtle.available_extensions() where name = _extname) then
    return;
  end if;

  if _extversion is null then
    select default_version
    from pgtle.available_extensions()
    where name = _extname
    into _extversion;
  end if;

  if _extschema is null then
    select schema
    from pgtle.available_extension_versions()
    where name = _extname and version = _extversion
    into _extschema;
  end if;

  for _r in (
    with recursive available_extensions(name, default_version) as (
      select name, default_version
      from pg_available_extensions
      union
      select name, default_version
      from pgtle.available_extensions()
    )
    , available_extension_versions(name, version, requires) as (
      select name, version, requires
      from pg_available_extension_versions
      union
      select name, version, requires
      from pgtle.available_extension_versions()
    )
    , all_dependencies(name, dependency) as (
      select e.name, unnest(ev.requires) as dependency
      from available_extensions e
      join available_extension_versions ev on ev.name = e.name and ev.version = e.default_version
    )
    , dependencies(name) AS (
        select unnest(requires)
        from available_extension_versions
        where name = _extname and version = _extversion
        union
        select all_dependencies.dependency
        from all_dependencies
        join dependencies d on d.name = all_dependencies.name
    )
    select name
    from dependencies
    intersect
    select name
    from regexp_split_to_table(current_setting('supautils.privileged_extensions', true), '\s*,\s*') as t(name)
  ) loop
    if _extschema is null then
      execute(format('create extension if not exists %I cascade', _r.name));
    else
      execute(format('create extension if not exists %I schema %I cascade', _r.name, _extschema));
    end if;
  end loop;
end $$;

reset client_min_messages;
reset log_min_messages;
```

</details>

It ain't pretty, but it works - and we can use it for other stuff.