### PR TITLE
feat: allow privileged_role to create ALL TABLES publication

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -37,7 +37,7 @@ let
 
       PGTZ=UTC initdb --no-locale --encoding=UTF8 --nosync -U "$PGUSER"
 
-      options="-F -c listen_addresses=\"\" -k $PGDATA -c shared_preload_libraries=\"pg_tle, supautils\""
+      options="-F -c listen_addresses=\"\" -k $PGDATA -c shared_preload_libraries=\"pg_tle, supautils\" -c wal_level=logical"
 
       reserved_roles="supabase_storage_admin, anon, reserved_but_not_yet_created, authenticator*"
       reserved_memberships="pg_read_server_files, pg_write_server_files, pg_execute_server_program, role_with_reserved_membership"

--- a/test/expected/privileged_role.out
+++ b/test/expected/privileged_role.out
@@ -156,3 +156,9 @@ set role privileged_role_member;
 grant testme to authenticator;
 NOTICE:  role "authenticator" is already a member of role "testme"
 set role privileged_role;
+\echo
+
+-- privileged_role can manage publications
+create publication p for all tables;
+drop publication p;
+-- not testing `create publication ... for tables in schema ...` because it's PG15+

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -13,3 +13,4 @@ create role privileged_role login createrole;
 create role privileged_role_member login createrole in role privileged_role;
 create role testme noinherit;
 create role authenticator login noinherit;
+grant all on database postgres to privileged_role;

--- a/test/sql/privileged_role.sql
+++ b/test/sql/privileged_role.sql
@@ -127,3 +127,9 @@ set role privileged_role_member;
 grant testme to authenticator;
 
 set role privileged_role;
+\echo
+
+-- privileged_role can manage publications
+create publication p for all tables;
+drop publication p;
+-- not testing `create publication ... for tables in schema ...` because it's PG15+


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

privileged_role can't manage `ALL TABLES` or `TABLES IN SCHEMA` (PG15+) publications

## What is the new behavior?

privileged_role can `create publication p for all tables`, `alter publication p add tables in schema public`, etc.
