### PR TITLE
test: constrained_extensions valid json config 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,3 +17,5 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
     - name: Run tests
       run: nix-shell --run "supautils-with-pg-${{ matrix.pg-version }} make installcheck"
+    - if: ${{ failure() }}
+      run: cat regression.diffs

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ regression.*
 venv/
 site/
 results/*.out
+.history
+result*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-PG_CFLAGS = -Wall -Werror
+ifeq ($(TEST), 1)
+	PG_CFLAGS = -Wall -Werror -DTEST
+else
+	PG_CFLAGS = -Wall -Werror
+endif
 
 DATA = $(wildcard sql/*--*.sql)
 

--- a/nix/pgScript.nix
+++ b/nix/pgScript.nix
@@ -1,0 +1,57 @@
+{ postgresql, writeShellScriptBin } :
+
+let
+  LOGMIN = builtins.getEnv "LOGMIN";
+  logMin = if builtins.stringLength LOGMIN == 0 then "WARNING" else LOGMIN; # warning is the default in pg
+  ver = builtins.head (builtins.splitVersion postgresql.version);
+  script = ''
+    export PATH=${postgresql}/bin:"$PATH"
+
+    tmpdir="$(mktemp -d)"
+
+    export PGDATA="$tmpdir"
+    export PGHOST="$tmpdir"
+    export PGUSER=postgres
+    export PGDATABASE=postgres
+
+    trap 'pg_ctl stop -m i && rm -rf "$tmpdir"' sigint sigterm exit
+
+    PGTZ=UTC initdb --no-locale --encoding=UTF8 --nosync -U "$PGUSER"
+
+    options="-F -c listen_addresses=\"\" -k $PGDATA -c shared_preload_libraries=\"pg_tle, supautils\" -c wal_level=logical"
+
+    reserved_roles="supabase_storage_admin, anon, reserved_but_not_yet_created, authenticator*"
+    reserved_memberships="pg_read_server_files, pg_write_server_files, pg_execute_server_program, role_with_reserved_membership"
+    privileged_extensions="hstore, postgres_fdw, pg_tle"
+    privileged_extensions_custom_scripts_path="$tmpdir/privileged_extensions_custom_scripts"
+    privileged_role="privileged_role"
+    privileged_role_allowed_configs="session_replication_role, pgrst.*, other.nested.*"
+
+    reserved_stuff_options="-c supautils.reserved_roles=\"$reserved_roles\" -c supautils.reserved_memberships=\"$reserved_memberships\" -c supautils.privileged_extensions=\"$privileged_extensions\" -c supautils.privileged_extensions_custom_scripts_path=\"$privileged_extensions_custom_scripts_path\" -c supautils.privileged_role=\"$privileged_role\" -c supautils.privileged_role_allowed_configs=\"$privileged_role_allowed_configs\""
+    placeholder_stuff_options='-c supautils.placeholders="response.headers, another.placeholder" -c supautils.placeholders_disallowed_values="\"content-type\",\"x-special-header\",special-value"'
+
+    cexts_option='-c supautils.constrained_extensions="{\"adminpack\": { \"cpu\": 64}, \"cube\": { \"mem\": \"17 GB\"}, \"lo\": { \"disk\": \"20 GB\"}, \"amcheck\": { \"cpu\": 2, \"mem\": \"100 MB\", \"disk\": \"100 MB\"}}"'
+
+    pg_ctl start -o "$options" -o "$reserved_stuff_options" -o "$placeholder_stuff_options" -o "$cexts_option"
+
+    mkdir -p "$tmpdir/privileged_extensions_custom_scripts/hstore"
+    echo "do \$\$
+          begin
+            if not exists (select from pg_extension where extname = 'pg_tle') then
+              return;
+            end if;
+            if exists (select from pgtle.available_extensions() where name = @extname@) then
+              raise notice 'extname: %, extschema: %, extversion: %, extcascade: %', @extname@, @extschema@, @extversion@, @extcascade@;
+            end if;
+          end \$\$;" > "$tmpdir/privileged_extensions_custom_scripts/before-create.sql"
+    echo 'create table t1();' > "$tmpdir/privileged_extensions_custom_scripts/hstore/before-create.sql"
+    echo 'drop table t1; create table t2 as values (1);' > "$tmpdir/privileged_extensions_custom_scripts/hstore/after-create.sql"
+
+    createdb contrib_regression
+
+    psql -v ON_ERROR_STOP=1 -f test/fixtures.sql -d contrib_regression
+
+    "$@"
+  '';
+in
+writeShellScriptBin "supautils-with-pg-${ver}" script

--- a/nix/supautils.nix
+++ b/nix/supautils.nix
@@ -1,9 +1,10 @@
-{ stdenv, postgresql }:
+{ stdenv, postgresql, extraMakeFlags ? "" }:
 
 stdenv.mkDerivation {
   name = "supautils";
   buildInputs = [ postgresql ];
   src = ../.;
+  makeFlags = [ extraMakeFlags ];
   installPhase = ''
     mkdir -p $out/lib
     install -D supautils.so -t $out/lib

--- a/nix/supautils.nix
+++ b/nix/supautils.nix
@@ -1,0 +1,11 @@
+{ stdenv, postgresql }:
+
+stdenv.mkDerivation {
+  name = "supautils";
+  buildInputs = [ postgresql ];
+  src = ../.;
+  installPhase = ''
+    mkdir -p $out/lib
+    install -D supautils.so -t $out/lib
+  '';
+}

--- a/shell.nix
+++ b/shell.nix
@@ -11,11 +11,11 @@ let
     postgresql_15
   ];
   pgWithExt = { postgresql }: postgresql.withPackages (p: [
-    (callPackage ./nix/supautils.nix { inherit postgresql; })
+    (callPackage ./nix/supautils.nix { inherit postgresql; extraMakeFlags = "TEST=1"; })
     (callPackage ./nix/pg_tle.nix { inherit postgresql; })
   ]);
   pgScriptAll = map (x: callPackage ./nix/pgScript.nix { postgresql = pgWithExt { postgresql = x;}; }) supportedPgVersions;
 in
 mkShell {
-  buildInputs = [  pgScriptAll ];
+  buildInputs = [ pgScriptAll ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -4,82 +4,18 @@ with import (builtins.fetchTarball {
   sha256 = "101y90kqqfqc5vkigw5rbcqw01cg9nndknz4q4gb28zi4918r1hz";
 }) {};
 let
-  supautils = { postgresql }:
-    stdenv.mkDerivation {
-      name = "supautils";
-      buildInputs = [ postgresql ];
-      src = ./.;
-      installPhase = ''
-        mkdir -p $out/lib
-        install -D supautils.so -t $out/lib
-      '';
-    };
-  pgWithExt = { postgresql } :
-  let
-    pg = postgresql.withPackages (p: [
-      (supautils { inherit postgresql; })
-      (callPackage ./nix/pg_tle.nix { inherit postgresql; })
-    ]);
-    ver = builtins.head (builtins.splitVersion postgresql.version);
-    script = ''
-      export PATH=${pg}/bin:"$PATH"
-
-      tmpdir="$(mktemp -d)"
-
-      export PGDATA="$tmpdir"
-      export PGHOST="$tmpdir"
-      export PGUSER=postgres
-      export PGDATABASE=postgres
-
-      trap 'pg_ctl stop -m i && rm -rf "$tmpdir"' sigint sigterm exit
-
-      PGTZ=UTC initdb --no-locale --encoding=UTF8 --nosync -U "$PGUSER"
-
-      options="-F -c listen_addresses=\"\" -k $PGDATA -c shared_preload_libraries=\"pg_tle, supautils\" -c wal_level=logical"
-
-      reserved_roles="supabase_storage_admin, anon, reserved_but_not_yet_created, authenticator*"
-      reserved_memberships="pg_read_server_files, pg_write_server_files, pg_execute_server_program, role_with_reserved_membership"
-      privileged_extensions="hstore, postgres_fdw, pg_tle"
-      privileged_extensions_custom_scripts_path="$tmpdir/privileged_extensions_custom_scripts"
-      privileged_role="privileged_role"
-      privileged_role_allowed_configs="session_replication_role, pgrst.*, other.nested.*"
-
-      reserved_stuff_options="-c supautils.reserved_roles=\"$reserved_roles\" -c supautils.reserved_memberships=\"$reserved_memberships\" -c supautils.privileged_extensions=\"$privileged_extensions\" -c supautils.privileged_extensions_custom_scripts_path=\"$privileged_extensions_custom_scripts_path\" -c supautils.privileged_role=\"$privileged_role\" -c supautils.privileged_role_allowed_configs=\"$privileged_role_allowed_configs\""
-      placeholder_stuff_options='-c supautils.placeholders="response.headers, another.placeholder" -c supautils.placeholders_disallowed_values="\"content-type\",\"x-special-header\",special-value"'
-
-      cexts_option='-c supautils.constrained_extensions="{\"adminpack\": { \"cpu\": 64}, \"cube\": { \"mem\": \"17 GB\"}, \"lo\": { \"disk\": \"20 GB\"}, \"amcheck\": { \"cpu\": 2, \"mem\": \"100 MB\", \"disk\": \"100 MB\"}}"'
-
-      pg_ctl start -o "$options" -o "$reserved_stuff_options" -o "$placeholder_stuff_options" -o "$cexts_option"
-
-      mkdir -p "$tmpdir/privileged_extensions_custom_scripts/hstore"
-      echo "do \$\$
-            begin
-              if not exists (select from pg_extension where extname = 'pg_tle') then
-                return;
-              end if;
-              if exists (select from pgtle.available_extensions() where name = @extname@) then
-                raise notice 'extname: %, extschema: %, extversion: %, extcascade: %', @extname@, @extschema@, @extversion@, @extcascade@;
-              end if;
-            end \$\$;" > "$tmpdir/privileged_extensions_custom_scripts/before-create.sql"
-      echo 'create table t1();' > "$tmpdir/privileged_extensions_custom_scripts/hstore/before-create.sql"
-      echo 'drop table t1; create table t2 as values (1);' > "$tmpdir/privileged_extensions_custom_scripts/hstore/after-create.sql"
-
-      createdb contrib_regression
-
-      psql -v ON_ERROR_STOP=1 -f test/fixtures.sql -d contrib_regression
-
-      "$@"
-    '';
-  in
-    writeShellScriptBin "supautils-with-pg-${ver}" script;
-    supportedPgVersions = [
-      postgresql_12
-      postgresql_13
-      postgresql_14
-      postgresql_15
-    ];
-  extAll = map (x: pgWithExt { postgresql = x;}) supportedPgVersions;
+  supportedPgVersions = [
+    postgresql_12
+    postgresql_13
+    postgresql_14
+    postgresql_15
+  ];
+  pgWithExt = { postgresql }: postgresql.withPackages (p: [
+    (callPackage ./nix/supautils.nix { inherit postgresql; })
+    (callPackage ./nix/pg_tle.nix { inherit postgresql; })
+  ]);
+  pgScriptAll = map (x: callPackage ./nix/pgScript.nix { postgresql = pgWithExt { postgresql = x;}; }) supportedPgVersions;
 in
 mkShell {
-  buildInputs = [ extAll ];
+  buildInputs = [  pgScriptAll ];
 }

--- a/src/constrained_extensions.c
+++ b/src/constrained_extensions.c
@@ -139,6 +139,11 @@ json_scalar(void *state, char *token, JsonTokenType tokentype)
 			parse->error_msg = "unexpected scalar, expected an object";
 			break;
 
+		case JCE_EXPECT_CONSTRAINTS_START:
+			parse->state = JCE_UNEXPECTED_SCALAR;
+			parse->error_msg = "unexpected scalar, expected an object";
+			break;
+
 		default:
 			break;
 	}

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -213,7 +213,7 @@ _PG_init(void)
 							   NULL,
 							   &constrained_extensions_str,
 							   NULL,
-							   PGC_SIGHUP, 0,
+							   SUPAUTILS_GUC_CONTEXT_SIGHUP, 0,
 							   NULL,
 							   constrained_extensions_assign_hook,
 							   NULL);

--- a/src/utils.h
+++ b/src/utils.h
@@ -53,6 +53,13 @@
         standard_ProcessUtility(PROCESS_UTILITY_ARGS);                         \
     }
 
+// helper for testing a guc config
+#if TEST
+#define SUPAUTILS_GUC_CONTEXT_SIGHUP PGC_USERSET
+#else
+#define SUPAUTILS_GUC_CONTEXT_SIGHUP PGC_SIGHUP
+#endif
+
 extern void
 alter_role_with_bypassrls_option_as_superuser(const char *role_name,
                                               DefElem *bypassrls_option,

--- a/test/expected/constrained_extensions.out
+++ b/test/expected/constrained_extensions.out
@@ -32,3 +32,30 @@ create extension amcheck;
 
 -- no resource constraints
 create extension bloom;
+\echo
+
+-- check json validation works
+set supautils.constrained_extensions to '';
+ERROR:  supautils.constrained_extensions: invalid json
+set supautils.constrained_extensions to '[]';
+ERROR:  supautils.constrained_extensions: unexpected array
+set supautils.constrained_extensions to '1';
+ERROR:  supautils.constrained_extensions: unexpected scalar, expected an object
+set supautils.constrained_extensions to '"foo"';
+ERROR:  supautils.constrained_extensions: unexpected scalar, expected an object
+set supautils.constrained_extensions to '{"plrust": []}';
+ERROR:  supautils.constrained_extensions: unexpected array
+set supautils.constrained_extensions to '{"plrust": {"cpu": true}}';
+ERROR:  supautils.constrained_extensions: unexpected cpu value, expected a number
+set supautils.constrained_extensions to '{"plrust": {"cpu": {}}}';
+ERROR:  supautils.constrained_extensions: unexpected object for cpu, mem or disk, expected a value
+set supautils.constrained_extensions to '{"plrust": {"anykey": "11GB"}}';
+ERROR:  supautils.constrained_extensions: unexpected field, only cpu, mem or disk are allowed
+set supautils.constrained_extensions to '{"plrust": {"disk": 123}}';
+ERROR:  supautils.constrained_extensions: unexpected disk value, expected a string with bytes in human-readable format (as returned by pg_size_pretty)
+set supautils.constrained_extensions to '{"plrust": {"mem": 456}}';
+ERROR:  supautils.constrained_extensions: unexpected mem value, expected a string with bytes in human-readable format (as returned by pg_size_pretty)
+set supautils.constrained_extensions to '{"plrust": {"mem": ""}}';
+ERROR:  invalid size: ""
+set supautils.constrained_extensions to '{"plrust": 123}';
+ERROR:  supautils.constrained_extensions: unexpected scalar, expected an object

--- a/test/expected/constrained_extensions_1.out
+++ b/test/expected/constrained_extensions_1.out
@@ -23,3 +23,18 @@ create extension amcheck;
 
 -- no resource constraints
 create extension bloom;
+\echo
+
+-- check json validation works
+set supautils.constrained_extensions to '';
+set supautils.constrained_extensions to '[]';
+set supautils.constrained_extensions to '1';
+set supautils.constrained_extensions to '"foo"';
+set supautils.constrained_extensions to '{"plrust": []}';
+set supautils.constrained_extensions to '{"plrust": {"cpu": true}}';
+set supautils.constrained_extensions to '{"plrust": {"cpu": {}}}';
+set supautils.constrained_extensions to '{"plrust": {"anykey": "11GB"}}';
+set supautils.constrained_extensions to '{"plrust": {"disk": 123}}';
+set supautils.constrained_extensions to '{"plrust": {"mem": 456}}';
+set supautils.constrained_extensions to '{"plrust": {"mem": ""}}';
+set supautils.constrained_extensions to '{"plrust": 123}';

--- a/test/sql/constrained_extensions.sql
+++ b/test/sql/constrained_extensions.sql
@@ -19,3 +19,18 @@ create extension amcheck;
 
 -- no resource constraints
 create extension bloom;
+\echo
+
+-- check json validation works
+set supautils.constrained_extensions to '';
+set supautils.constrained_extensions to '[]';
+set supautils.constrained_extensions to '1';
+set supautils.constrained_extensions to '"foo"';
+set supautils.constrained_extensions to '{"plrust": []}';
+set supautils.constrained_extensions to '{"plrust": {"cpu": true}}';
+set supautils.constrained_extensions to '{"plrust": {"cpu": {}}}';
+set supautils.constrained_extensions to '{"plrust": {"anykey": "11GB"}}';
+set supautils.constrained_extensions to '{"plrust": {"disk": 123}}';
+set supautils.constrained_extensions to '{"plrust": {"mem": 456}}';
+set supautils.constrained_extensions to '{"plrust": {"mem": ""}}';
+set supautils.constrained_extensions to '{"plrust": 123}';


### PR DESCRIPTION
Passes a make flag so `supautils.constrained_extensions` goes from `PGC_SIGHUP` context (only editable in config file) to `PGC_USERSET` (editable in SQL). This way the json validation can be tested in regular `.sql/.out` tests.

* Adds tests for `supautils.constrained_extensions` json validation.
* Also a fix for wrong json scalar when expecting object