### PR TITLE
fix: prevent nested `switch_to_superuser()` from corrupting `prev_role_*`

### DIFF
--- a/nix/withTmpDb.sh.in
+++ b/nix/withTmpDb.sh.in
@@ -15,7 +15,7 @@ options="-F -c listen_addresses=\"\" -k $PGDATA -c shared_preload_libraries=\"pg
 
 reserved_roles="supabase_storage_admin, anon, reserved_but_not_yet_created, authenticator*"
 reserved_memberships="pg_read_server_files, pg_write_server_files, pg_execute_server_program, role_with_reserved_membership"
-privileged_extensions="hstore, postgres_fdw, pg_tle"
+privileged_extensions="autoinc, citext, hstore, postgres_fdw, pg_tle"
 privileged_extensions_custom_scripts_path="$tmpdir/privileged_extensions_custom_scripts"
 privileged_role="privileged_role"
 privileged_role_allowed_configs="session_replication_role, pgrst.*, other.nested.*"
@@ -27,7 +27,8 @@ cexts_option='-c supautils.constrained_extensions="{\"adminpack\": { \"cpu\": 64
 
 pg_ctl start -o "$options" -o "$reserved_stuff_options" -o "$placeholder_stuff_options" -o "$cexts_option"
 
-mkdir -p "$tmpdir/privileged_extensions_custom_scripts/hstore"
+# print notice when creating a TLE
+mkdir -p "$tmpdir/privileged_extensions_custom_scripts"
 echo "do \$\$
       begin
         if not exists (select from pg_extension where extname = 'pg_tle') then
@@ -37,6 +38,12 @@ echo "do \$\$
           raise notice 'extname: %, extschema: %, extversion: %, extcascade: %', @extname@, @extschema@, @extversion@, @extcascade@;
         end if;
       end \$\$;" > "$tmpdir/privileged_extensions_custom_scripts/before-create.sql"
+
+mkdir -p "$tmpdir/privileged_extensions_custom_scripts/autoinc"
+echo 'create extension citext;' > "$tmpdir/privileged_extensions_custom_scripts/autoinc/after-create.sql"
+
+# assert both before-create and after-create scripts are run
+mkdir -p "$tmpdir/privileged_extensions_custom_scripts/hstore"
 echo 'create table t1();' > "$tmpdir/privileged_extensions_custom_scripts/hstore/before-create.sql"
 echo 'drop table t1; create table t2 as values (1);' > "$tmpdir/privileged_extensions_custom_scripts/hstore/after-create.sql"
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 with import (builtins.fetchTarball {
-  name = "2022-10-25";
-  url = "https://github.com/NixOS/nixpkgs/archive/a11f8032aa9de58be11190b71320f98f9a3c395b.tar.gz";
-  sha256 = "101y90kqqfqc5vkigw5rbcqw01cg9nndknz4q4gb28zi4918r1hz";
+  name = "23.11";
+  url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/23.11.tar.gz";
+  sha256 = "1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k";
 }) {};
 let
   supportedPgVersions = [

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -352,11 +352,14 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 				}
 
 				{
-					switch_to_superuser(privileged_extensions_superuser);
+					bool already_switched_to_superuser = false;
+					switch_to_superuser(privileged_extensions_superuser, &already_switched_to_superuser);
 
 					run_process_utility_hook(prev_hook);
 
-					switch_to_original_role();
+					if (!already_switched_to_superuser) {
+						switch_to_original_role();
+					}
 
 					return;
 				}
@@ -595,6 +598,7 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 		case T_CreateFdwStmt:
 		{
 			const Oid current_user_id = GetUserId();
+			bool already_switched_to_superuser = false;
 
 			if (superuser()) {
 				break;
@@ -603,7 +607,7 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 				break;
 			}
 
-			switch_to_superuser(privileged_extensions_superuser);
+			switch_to_superuser(privileged_extensions_superuser, &already_switched_to_superuser);
 
 			run_process_utility_hook(prev_hook);
 
@@ -646,7 +650,9 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 				PopActiveSnapshot();
 			}
 
-			switch_to_original_role();
+			if (!already_switched_to_superuser) {
+				switch_to_original_role();
+			}
 
 			return;
 		}
@@ -657,6 +663,7 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 		case T_CreatePublicationStmt:
 		{
 			const Oid current_user_id = GetUserId();
+			bool already_switched_to_superuser = false;
 
 			if (superuser()) {
 				break;
@@ -665,7 +672,7 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 				break;
 			}
 
-			switch_to_superuser(privileged_extensions_superuser);
+			switch_to_superuser(privileged_extensions_superuser, &already_switched_to_superuser);
 
 			run_process_utility_hook(prev_hook);
 
@@ -703,7 +710,9 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 				PopActiveSnapshot();
 			}
 
-			switch_to_original_role();
+			if (!already_switched_to_superuser) {
+				switch_to_original_role();
+			}
 
 			return;
 		}
@@ -713,6 +722,8 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 		 */
 		case T_AlterPublicationStmt:
 		{
+			bool already_switched_to_superuser = false;
+
 			if (superuser()) {
 				break;
 			}
@@ -720,11 +731,13 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 				break;
 			}
 
-			switch_to_superuser(privileged_extensions_superuser);
+			switch_to_superuser(privileged_extensions_superuser, &already_switched_to_superuser);
 
 			run_process_utility_hook(prev_hook);
 
-			switch_to_original_role();
+			if (!already_switched_to_superuser) {
+				switch_to_original_role();
+			}
 
 			return;
 		}
@@ -770,11 +783,14 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 			}
 
 			{
-				switch_to_superuser(privileged_extensions_superuser);
+				bool already_switched_to_superuser = false;
+				switch_to_superuser(privileged_extensions_superuser, &already_switched_to_superuser);
 
 				run_process_utility_hook(prev_hook);
 
-				switch_to_original_role();
+		     	if (!already_switched_to_superuser) {
+		     		switch_to_original_role();
+		     	}
 
 				return;
 			}
@@ -802,11 +818,14 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 			}
 
 			{
-				switch_to_superuser(privileged_extensions_superuser);
+				bool already_switched_to_superuser = false;
+				switch_to_superuser(privileged_extensions_superuser, &already_switched_to_superuser);
 
 				run_process_utility_hook(prev_hook);
 
-				switch_to_original_role();
+		     	if (!already_switched_to_superuser) {
+		     		switch_to_original_role();
+		     	}
 
 				return;
 			}

--- a/src/utils.h
+++ b/src/utils.h
@@ -69,7 +69,8 @@ alter_role_with_bypassrls_option_as_superuser(const char *role_name,
  * Switch to a superuser and save the original role. Caller is responsible for
  * calling switch_to_original_role() afterwards.
  */
-extern void switch_to_superuser(const char *privileged_extensions_superuser);
+extern void switch_to_superuser(const char *privileged_extensions_superuser,
+                                bool *already_switched);
 
 /**
  * Restore the saved original role. Caller is responsible for ensuring

--- a/test/expected/privileged_extensions.out
+++ b/test/expected/privileged_extensions.out
@@ -31,6 +31,8 @@ set role extensions_role;
 -- global extension custom scripts are run
 create extension pg_tle;
 reset role;
+-- must run this after `create extension pg_tle` since the role only exists
+-- after the ext is created
 grant pgtle_admin to extensions_role;
 set role extensions_role;
 select pgtle.install_extension('foo', '1', '', 'select 1', '{}');
@@ -63,6 +65,16 @@ set role extensions_role;
 \echo
 
 -- cannot create other extensions
-create extension moddatetime;
-ERROR:  permission denied to create extension "moddatetime"
+create extension file_fdw;
+ERROR:  permission denied to create extension "file_fdw"
 HINT:  Must be superuser to create this extension.
+\echo
+
+-- original role is restored on nested switch_to_superuser()
+create extension autoinc;
+select current_role;
+  current_role   
+-----------------
+ extensions_role
+(1 row)
+

--- a/test/sql/privileged_extensions.sql
+++ b/test/sql/privileged_extensions.sql
@@ -23,6 +23,8 @@ set role extensions_role;
 -- global extension custom scripts are run
 create extension pg_tle;
 reset role;
+-- must run this after `create extension pg_tle` since the role only exists
+-- after the ext is created
 grant pgtle_admin to extensions_role;
 set role extensions_role;
 select pgtle.install_extension('foo', '1', '', 'select 1', '{}');
@@ -42,4 +44,9 @@ set role extensions_role;
 \echo
 
 -- cannot create other extensions
-create extension moddatetime;
+create extension file_fdw;
+\echo
+
+-- original role is restored on nested switch_to_superuser()
+create extension autoinc;
+select current_role;


### PR DESCRIPTION
This caused an issue here: https://github.com/supabase/postgres/actions/runs/7551764226/job/20561373521#step:15:4305

TODO:
- [x] tests