### PR TITLE
fix: disable sysinfo checks on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,14 @@ OBJS = src/supautils.o src/privileged_extensions.o src/constrained_extensions.o 
 
 PG_VERSION = $(strip $(shell $(PG_CONFIG) --version | $(GREP) -oP '(?<=PostgreSQL )[0-9]+'))
 PG_GE13 = $(shell test $(PG_VERSION) -ge 13; echo $$?)
+SYSTEM = $(shell uname -s)
 
-ifeq ($(PG_GE13),0)
-TESTS = $(wildcard test/sql/*.sql)
-else
+ifneq ($(SYSTEM), Linux)
 TESTS = $(filter-out test/sql/ge13_%.sql, $(wildcard test/sql/*.sql))
+else ifneq ($(PG_GE13), 0)
+TESTS = $(filter-out test/sql/ge13_%.sql, $(wildcard test/sql/*.sql))
+else
+TESTS = $(wildcard test/sql/*.sql)
 endif
 
 REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))


### PR DESCRIPTION
can't compile on macos otherwise