### PR TITLE
feat: extensions parameter overrides

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,6 @@ jobs:
           mkdir -p ${package_dir}/usr/lib/postgresql/lib
           mkdir -p ${package_dir}/var/lib/postgresql/extension
           cp *.so ${package_dir}/usr/lib/postgresql/lib
-          cp *.control ${package_dir}/var/lib/postgresql/extension
 
           # symlinks to Copy files into directory structure
           mkdir -p ${package_dir}/usr/lib/postgresql/${{ matrix.postgres }}/lib
@@ -76,7 +75,6 @@ jobs:
 
           mkdir -p ${package_dir}/usr/share/postgresql/${{ matrix.postgres }}/extension
           cd ${package_dir}/usr/share/postgresql/${{ matrix.postgres }}/extension
-          cp -s ../../../../../var/lib/postgresql/extension/${{ matrix.extension_name }}.control .
           cd ../../../../../..
 
           # Create install control file

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,8 @@ else
 endif
 
 MODULE_big = supautils
-OBJS = src/supautils.o src/privileged_extensions.o src/constrained_extensions.o src/utils.o
+OBJS = src/supautils.o src/privileged_extensions.o src/constrained_extensions.o src/extensions_parameter_overrides.o src/utils.o
 
-PG_VERSION = $(strip $(shell $(PG_CONFIG) --version | $(GREP) -oP '(?<=PostgreSQL )[0-9]+'))
 SYSTEM = $(shell uname -s)
 
 ifneq ($(SYSTEM), Linux)

--- a/README.md
+++ b/README.md
@@ -156,7 +156,28 @@ DETAIL:  required CPUs: 16
 HINT:  upgrade to an instance with higher resources
 ```
 
-This feature is only available from PostgreSQL 13 onwards.
+## Extensions Parameter Overrides
+
+You can override `CREATE EXTENSION` parameters like so:
+
+```
+supautils.extensions_parameter_overrides = '{ "pg_cron": { "schema": "pg_catalog" } }'
+```
+
+Currently, only the `schema` parameter is supported.
+
+These overrides will apply on `CREATE EXTENSION`, e.g.:
+
+```sql
+postgres=> create extension pg_cron schema public;
+CREATE EXTENSION
+postgres=> \dx pg_cron
+                 List of installed extensions
+  Name   | Version |   Schema   |         Description
+---------+---------+------------+------------------------------
+ pg_cron | 1.5     | pg_catalog | Job scheduler for PostgreSQL
+(1 row)
+```
 
 ## Development
 

--- a/nix/pg_cron.nix
+++ b/nix/pg_cron.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchFromGitHub, postgresql }:
+
+stdenv.mkDerivation rec {
+  pname = "pg_cron";
+  version = "1.5.2";
+
+  buildInputs = [ postgresql ];
+
+  src = fetchFromGitHub {
+    owner  = "citusdata";
+    repo   = pname;
+    rev    = "v${version}";
+    hash   = "sha256-+quVWbKJy6wXpL/zwTk5FF7sYwHA7I97WhWmPO/HSZ4=";
+  };
+
+  installPhase = ''
+    mkdir -p $out/{lib,share/postgresql/extension}
+
+    cp *.so      $out/lib
+    cp *.sql     $out/share/postgresql/extension
+    cp *.control $out/share/postgresql/extension
+  '';
+
+  meta = with lib; {
+    description = "Run Cron jobs through PostgreSQL";
+    homepage    = "https://github.com/citusdata/pg_cron";
+    changelog   = "https://github.com/citusdata/pg_cron/raw/v${version}/CHANGELOG.md";
+    maintainers = with maintainers; [ thoughtpolice ];
+    platforms   = postgresql.meta.platforms;
+    license     = licenses.postgresql;
+  };
+}

--- a/nix/withTmpDb.sh.in
+++ b/nix/withTmpDb.sh.in
@@ -11,11 +11,11 @@ trap 'pg_ctl stop -m i && rm -rf "$tmpdir"' sigint sigterm exit
 
 PGTZ=UTC initdb --no-locale --encoding=UTF8 --nosync -U "$PGUSER"
 
-options="-F -c listen_addresses=\"\" -k $PGDATA -c shared_preload_libraries=\"pg_tle, supautils\" -c wal_level=logical"
+options="-F -c listen_addresses=\"\" -k $PGDATA -c shared_preload_libraries=\"pg_cron, pg_tle, supautils\" -c wal_level=logical -c cron.database_name=postgres"
 
 reserved_roles="supabase_storage_admin, anon, reserved_but_not_yet_created, authenticator*"
 reserved_memberships="pg_read_server_files, pg_write_server_files, pg_execute_server_program, role_with_reserved_membership"
-privileged_extensions="autoinc, citext, hstore, postgres_fdw, pg_tle"
+privileged_extensions="autoinc, citext, hstore, pg_cron, pg_tle, postgres_fdw"
 privileged_extensions_custom_scripts_path="$tmpdir/privileged_extensions_custom_scripts"
 privileged_role="privileged_role"
 privileged_role_allowed_configs="session_replication_role, pgrst.*, other.nested.*"
@@ -25,7 +25,9 @@ placeholder_stuff_options='-c supautils.placeholders="response.headers, another.
 
 cexts_option='-c supautils.constrained_extensions="{\"adminpack\": { \"cpu\": 64}, \"cube\": { \"mem\": \"17 GB\"}, \"lo\": { \"disk\": \"20 GB\"}, \"amcheck\": { \"cpu\": 2, \"mem\": \"100 MB\", \"disk\": \"100 MB\"}}"'
 
-pg_ctl start -o "$options" -o "$reserved_stuff_options" -o "$placeholder_stuff_options" -o "$cexts_option"
+epos_option='-c supautils.extensions_parameter_overrides="{\"pg_cron\":{\"schema\":\"pg_catalog\"}}"'
+
+pg_ctl start -o "$options" -o "$reserved_stuff_options" -o "$placeholder_stuff_options" -o "$cexts_option" -o "$epos_option"
 
 # print notice when creating a TLE
 mkdir -p "$tmpdir/privileged_extensions_custom_scripts"

--- a/shell.nix
+++ b/shell.nix
@@ -11,6 +11,7 @@ let
   ];
   pgWithExt = { postgresql }: postgresql.withPackages (p: [
     (callPackage ./nix/supautils.nix { inherit postgresql; extraMakeFlags = "TEST=1"; })
+    (callPackage ./nix/pg_cron.nix { inherit postgresql; })
     (callPackage ./nix/pg_tle.nix { inherit postgresql; })
   ]);
   pgScriptAll = map (x: callPackage ./nix/pgScript.nix { postgresql = pgWithExt { postgresql = x;}; }) supportedPgVersions;

--- a/src/extensions_parameter_overrides.c
+++ b/src/extensions_parameter_overrides.c
@@ -1,0 +1,134 @@
+#include <postgres.h>
+
+#include <common/jsonapi.h>
+#include <miscadmin.h>
+#include <tsearch/ts_locale.h>
+#include <utils/builtins.h>
+#include <utils/json.h>
+#include <utils/jsonb.h>
+#include <utils/jsonfuncs.h>
+#include <utils/memutils.h>
+
+#include "extensions_parameter_overrides.h"
+
+static void json_array_start(void *state) {
+    json_extension_parameter_overrides_parse_state *parse = state;
+
+    parse->state = JEPO_UNEXPECTED_ARRAY;
+    parse->error_msg = "unexpected array";
+}
+
+static void json_object_start(void *state) {
+    json_extension_parameter_overrides_parse_state *parse = state;
+
+    switch (parse->state) {
+    case JEPO_EXPECT_TOPLEVEL_START:
+        parse->state = JEPO_EXPECT_TOPLEVEL_FIELD;
+        break;
+    case JEPO_EXPECT_SCHEMA:
+        parse->error_msg = "unexpected object for schema, expected a value";
+        parse->state = JEPO_UNEXPECTED_OBJECT;
+        break;
+    default:
+        break;
+    }
+}
+
+static void json_object_end(void *state) {
+    json_extension_parameter_overrides_parse_state *parse = state;
+
+    switch (parse->state) {
+    case JEPO_EXPECT_PARAMETER_OVERRIDES_START:
+        parse->state = JEPO_EXPECT_TOPLEVEL_FIELD;
+        (parse->total_epos)++;
+        break;
+    default:
+        break;
+    }
+}
+
+static void json_object_field_start(void *state, char *fname, bool isnull) {
+    json_extension_parameter_overrides_parse_state *parse = state;
+    extension_parameter_overrides *x = &parse->epos[parse->total_epos];
+
+    switch (parse->state) {
+    case JEPO_EXPECT_TOPLEVEL_FIELD:
+        x->name = MemoryContextStrdup(TopMemoryContext, fname);
+        parse->state = JEPO_EXPECT_PARAMETER_OVERRIDES_START;
+        break;
+
+    case JEPO_EXPECT_PARAMETER_OVERRIDES_START:
+        if (strcmp(fname, "schema") == 0)
+            parse->state = JEPO_EXPECT_SCHEMA;
+        else {
+            parse->state = JEPO_UNEXPECTED_FIELD;
+            parse->error_msg = "unexpected field, only schema is allowed";
+        }
+        break;
+
+    default:
+        break;
+    }
+}
+
+static void json_scalar(void *state, char *token, JsonTokenType tokentype) {
+    json_extension_parameter_overrides_parse_state *parse = state;
+    extension_parameter_overrides *x = &parse->epos[parse->total_epos];
+
+    switch (parse->state) {
+    case JEPO_EXPECT_SCHEMA:
+        if (tokentype == JSON_TOKEN_STRING) {
+            x->schema = MemoryContextStrdup(TopMemoryContext, token);
+            parse->state = JEPO_EXPECT_PARAMETER_OVERRIDES_START;
+        } else {
+            parse->state = JEPO_UNEXPECTED_SCHEMA_VALUE;
+            parse->error_msg = "unexpected schema value, expected a string";
+        }
+        break;
+
+    case JEPO_EXPECT_TOPLEVEL_START:
+        parse->state = JEPO_UNEXPECTED_SCALAR;
+        parse->error_msg = "unexpected scalar, expected an object";
+        break;
+
+    case JEPO_EXPECT_PARAMETER_OVERRIDES_START:
+        parse->state = JEPO_UNEXPECTED_SCALAR;
+        parse->error_msg = "unexpected scalar, expected an object";
+        break;
+
+    default:
+        break;
+    }
+}
+
+json_extension_parameter_overrides_parse_state
+parse_extensions_parameter_overrides(const char *str,
+                                     extension_parameter_overrides *epos) {
+    JsonLexContext *lex;
+    JsonParseErrorType json_error;
+    JsonSemAction sem;
+
+    json_extension_parameter_overrides_parse_state state = {
+        JEPO_EXPECT_TOPLEVEL_START, NULL, 0, epos};
+
+    lex =
+        makeJsonLexContextCstringLen(pstrdup(str), strlen(str), PG_UTF8, true);
+
+    sem.semstate = &state;
+    sem.object_start = json_object_start;
+    sem.object_end = json_object_end;
+    sem.array_start = json_array_start;
+    sem.array_end = NULL;
+    sem.object_field_start = json_object_field_start;
+    sem.object_field_end = NULL;
+    sem.array_element_start = NULL;
+    sem.array_element_end = NULL;
+    sem.scalar = json_scalar;
+
+    json_error = pg_parse_json(lex, &sem);
+
+    if (json_error != JSON_SUCCESS)
+        state.error_msg = "invalid json";
+
+    return state;
+}

--- a/src/extensions_parameter_overrides.h
+++ b/src/extensions_parameter_overrides.h
@@ -1,0 +1,34 @@
+#ifndef EXTENSIONS_PARAMETER_OVERRIDES_H
+#define EXTENSIONS_PARAMETER_OVERRIDES_H
+
+#include <postgres.h>
+
+typedef struct {
+    char *name;
+    char *schema;
+} extension_parameter_overrides;
+
+typedef enum {
+    JEPO_EXPECT_TOPLEVEL_START,
+    JEPO_EXPECT_TOPLEVEL_FIELD,
+    JEPO_EXPECT_PARAMETER_OVERRIDES_START,
+    JEPO_EXPECT_SCHEMA,
+    JEPO_UNEXPECTED_FIELD,
+    JEPO_UNEXPECTED_ARRAY,
+    JEPO_UNEXPECTED_SCALAR,
+    JEPO_UNEXPECTED_OBJECT,
+    JEPO_UNEXPECTED_SCHEMA_VALUE
+} json_extension_parameter_overrides_semantic_state;
+
+typedef struct {
+    json_extension_parameter_overrides_semantic_state state;
+    char *error_msg;
+    int total_epos;
+    extension_parameter_overrides *epos;
+} json_extension_parameter_overrides_parse_state;
+
+extern json_extension_parameter_overrides_parse_state
+parse_extensions_parameter_overrides(const char *str,
+                                     extension_parameter_overrides *epos);
+
+#endif

--- a/src/privileged_extensions.c
+++ b/src/privileged_extensions.c
@@ -213,8 +213,8 @@ void handle_create_extension(
     }
 
     // Run `CREATE EXTENSION`.
-    if (!superuser() && is_string_in_comma_delimited_string(
-                            stmt->extname, privileged_extensions)) {
+    if (is_string_in_comma_delimited_string(stmt->extname,
+                                            privileged_extensions)) {
         bool already_switched_to_superuser = false;
         switch_to_superuser(privileged_extensions_superuser,
                             &already_switched_to_superuser);

--- a/src/privileged_extensions.h
+++ b/src/privileged_extensions.h
@@ -1,14 +1,15 @@
 #ifndef PRIVILEGED_EXTENSIONS_H
 #define PRIVILEGED_EXTENSIONS_H
 
+#include "extensions_parameter_overrides.h"
 #include "utils.h"
 
-extern void
-handle_create_extension(void (*process_utility_hook)(PROCESS_UTILITY_PARAMS),
-                        PROCESS_UTILITY_PARAMS,
-                        const char *privileged_extensions,
-                        const char *privileged_extensions_superuser,
-                        const char *privileged_extensions_custom_scripts_path);
+extern void handle_create_extension(
+    void (*process_utility_hook)(PROCESS_UTILITY_PARAMS),
+    PROCESS_UTILITY_PARAMS, const char *privileged_extensions,
+    const char *privileged_extensions_superuser,
+    const char *privileged_extensions_custom_scripts_path,
+    const extension_parameter_overrides *epos, const size_t total_epos);
 
 extern void
 handle_alter_extension(void (*process_utility_hook)(PROCESS_UTILITY_PARAMS),

--- a/test/expected/privileged_extensions.out
+++ b/test/expected/privileged_extensions.out
@@ -88,3 +88,23 @@ select extnamespace::regnamespace from pg_extension where extname = 'pg_cron';
  pg_catalog
 (1 row)
 
+drop extension pg_cron;
+\echo
+
+-- switch to privileged_extensions_superuser even if superuser
+reset role;
+create role another_superuser superuser;
+set role another_superuser;
+create extension pg_cron;
+select extowner::regrole from pg_extension where extname = 'pg_cron';
+ extowner 
+----------
+ postgres
+(1 row)
+
+reset role;
+drop extension pg_cron;
+drop role another_superuser;
+set role extensions_role;
+\echo
+

--- a/test/expected/privileged_extensions.out
+++ b/test/expected/privileged_extensions.out
@@ -78,3 +78,13 @@ select current_role;
  extensions_role
 (1 row)
 
+\echo
+
+-- can force pg_cron to be installed in pg_catalog
+create extension pg_cron schema public;
+select extnamespace::regnamespace from pg_extension where extname = 'pg_cron';
+ extnamespace 
+--------------
+ pg_catalog
+(1 row)
+

--- a/test/sql/privileged_extensions.sql
+++ b/test/sql/privileged_extensions.sql
@@ -55,3 +55,19 @@ select current_role;
 -- can force pg_cron to be installed in pg_catalog
 create extension pg_cron schema public;
 select extnamespace::regnamespace from pg_extension where extname = 'pg_cron';
+
+drop extension pg_cron;
+\echo
+
+-- switch to privileged_extensions_superuser even if superuser
+reset role;
+create role another_superuser superuser;
+set role another_superuser;
+create extension pg_cron;
+select extowner::regrole from pg_extension where extname = 'pg_cron';
+
+reset role;
+drop extension pg_cron;
+drop role another_superuser;
+set role extensions_role;
+\echo

--- a/test/sql/privileged_extensions.sql
+++ b/test/sql/privileged_extensions.sql
@@ -50,3 +50,8 @@ create extension file_fdw;
 -- original role is restored on nested switch_to_superuser()
 create extension autoinc;
 select current_role;
+\echo
+
+-- can force pg_cron to be installed in pg_catalog
+create extension pg_cron schema public;
+select extnamespace::regnamespace from pg_extension where extname = 'pg_cron';


### PR DESCRIPTION
Allows overriding `create extension` parameters. E.g. with:

```
supautils.extensions_parameter_overrides = '{"pg_cron":{"schema":"pg_catalog"}}'
```

When someone runs `create extension pg_cron with schema public`, it gets created in `pg_catalog` instead:

```
postgres=> \dx
                 List of installed extensions
  Name   | Version |   Schema   |         Description          
---------+---------+------------+------------------------------
 pg_cron | 1.5     | pg_catalog | Job scheduler for PostgreSQL
 plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
(2 rows)
```

Currently only supports `schema`, but may support `version`, `owner`, etc. in the future.