### PR TITLE
fix: allow nosuperuser attribute to be set on roles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   test:

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -3,6 +3,7 @@
 #include <access/xact.h>
 #include <catalog/namespace.h>
 #include <catalog/pg_authid.h>
+#include <commands/defrem.h>
 #include <executor/spi.h>
 #include <fmgr.h>
 #include <miscadmin.h>
@@ -332,7 +333,7 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 				foreach(option_cell, stmt->options)
 				{
 					DefElem *defel = (DefElem *) lfirst(option_cell);
-					if (strcmp(defel->defname, "superuser") == 0) {
+					if (strcmp(defel->defname, "superuser") == 0 && defGetBoolean(defel)) {
 						ereport(ERROR,
 								(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 								 errmsg("permission denied to alter role"),
@@ -434,7 +435,7 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 							hasrolemembers = true;
 
 						// Setting the superuser attribute is not allowed.
-						if (strcmp(defel->defname, "superuser") == 0) {
+						if (strcmp(defel->defname, "superuser") == 0 && defGetBoolean(defel)) {
 							ereport(ERROR,
 									(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 									 errmsg("permission denied to create role"),

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -333,7 +333,7 @@ supautils_hook(PROCESS_UTILITY_PARAMS)
 				foreach(option_cell, stmt->options)
 				{
 					DefElem *defel = (DefElem *) lfirst(option_cell);
-					if (strcmp(defel->defname, "superuser") == 0 && defGetBoolean(defel)) {
+					if (strcmp(defel->defname, "superuser") == 0) {
 						ereport(ERROR,
 								(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 								 errmsg("permission denied to alter role"),

--- a/test/expected/privileged_role.out
+++ b/test/expected/privileged_role.out
@@ -176,11 +176,17 @@ alter role authenticator nologin;
 ERROR:  "authenticator" is a reserved role, only superusers can modify it
 \echo
 
--- privileged_role cannot manage superuser attribute
+-- privileged_role can create nosuperuser
+create role r nosuperuser;
+drop role r;
+\echo
+
+-- privileged_role cannot create superuser or alter [no]superuser
 create role r superuser;
 ERROR:  permission denied to create role
 DETAIL:  Only roles with the SUPERUSER attribute may create roles with the SUPERUSER attribute.
-create role r nosuperuser;
+create role r;
+alter role r nosuperuser;
 alter role r superuser;
 ERROR:  permission denied to alter role
 DETAIL:  Only roles with the SUPERUSER attribute may alter roles with the SUPERUSER attribute.

--- a/test/expected/privileged_role.out
+++ b/test/expected/privileged_role.out
@@ -180,7 +180,7 @@ ERROR:  "authenticator" is a reserved role, only superusers can modify it
 create role r superuser;
 ERROR:  permission denied to create role
 DETAIL:  Only roles with the SUPERUSER attribute may create roles with the SUPERUSER attribute.
-create role r;
+create role r nosuperuser;
 alter role r superuser;
 ERROR:  permission denied to alter role
 DETAIL:  Only roles with the SUPERUSER attribute may alter roles with the SUPERUSER attribute.

--- a/test/expected/privileged_role.out
+++ b/test/expected/privileged_role.out
@@ -176,7 +176,7 @@ alter role authenticator nologin;
 ERROR:  "authenticator" is a reserved role, only superusers can modify it
 \echo
 
--- privileged_role cannot manage [no]superuser attribute
+-- privileged_role cannot manage superuser attribute
 create role r superuser;
 ERROR:  permission denied to create role
 DETAIL:  Only roles with the SUPERUSER attribute may create roles with the SUPERUSER attribute.

--- a/test/expected/privileged_role.out
+++ b/test/expected/privileged_role.out
@@ -187,6 +187,8 @@ ERROR:  permission denied to create role
 DETAIL:  Only roles with the SUPERUSER attribute may create roles with the SUPERUSER attribute.
 create role r;
 alter role r nosuperuser;
+ERROR:  permission denied to alter role
+DETAIL:  Only roles with the SUPERUSER attribute may alter roles with the SUPERUSER attribute.
 alter role r superuser;
 ERROR:  permission denied to alter role
 DETAIL:  Only roles with the SUPERUSER attribute may alter roles with the SUPERUSER attribute.

--- a/test/sql/privileged_role.sql
+++ b/test/sql/privileged_role.sql
@@ -132,9 +132,9 @@ alter role authenticator rename to authorized;
 alter role authenticator nologin;
 \echo
 
--- privileged_role cannot manage [no]superuser attribute
+-- privileged_role cannot manage superuser attribute
 create role r superuser;
-create role r;
+create role r nosuperuser;
 alter role r superuser;
 alter role postgres nosuperuser;
 

--- a/test/sql/privileged_role.sql
+++ b/test/sql/privileged_role.sql
@@ -132,9 +132,16 @@ alter role authenticator rename to authorized;
 alter role authenticator nologin;
 \echo
 
--- privileged_role cannot manage superuser attribute
-create role r superuser;
+-- privileged_role can create nosuperuser
 create role r nosuperuser;
+
+drop role r;
+\echo
+
+-- privileged_role cannot create superuser or alter [no]superuser
+create role r superuser;
+create role r;
+alter role r nosuperuser;
 alter role r superuser;
 alter role postgres nosuperuser;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

relates to https://github.com/supabase/cli/issues/2224

## What is the new behavior?

Allows `create role r nosuperuser` to run.

## Additional context

Also requires rollout to platform.
