### PR TITLE
feat: compatibility with pg 17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg-version: ['13', '14', '15', '16']
+        pg-version: ['13', '14', '15', '16', '17']
 
     steps:
     - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ site/
 results/*.out
 .history
 result*
+tags

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Supautils is an extension that secures a PostgreSQL cluster on a cloud environme
 
 It doesn't require creating database objects. It's a shared library that modifies PostgreSQL behavior through "hooks", not through tables or functions.
 
-It's tested to work on PostgreSQL 13, 14, 15, and 16.
+It's tested to work on PostgreSQL 13, 14, 15, 16 and 17.
 
 ## Installation
 

--- a/nix/postgresql/17.nix
+++ b/nix/postgresql/17.nix
@@ -1,0 +1,4 @@
+import ./generic.nix {
+  version = "17.0";
+  hash = "sha256-fidhMcD91rYliNutmzuyS4w0mNUAkyjbpZrxboGRCd4=";
+}

--- a/nix/postgresql/default.nix
+++ b/nix/postgresql/default.nix
@@ -1,0 +1,27 @@
+self:
+let
+  # Before removing an EOL major version, make sure to check the versioning policy in:
+  # <nixpkgs>/nixos/modules/services/databases/postgresql.md
+  #
+  # Before removing, make sure to update it to the last minor version - and if only in
+  # an immediately preceding commit. This allows people relying on that old major version
+  # for a bit longer to still update up to this commit to at least get the latest minor
+  # version. In other words: Do not remove the second-to-last minor version from nixpkgs,
+  # yet. Update first.
+  versions = {
+    postgresql_17 = ./17.nix;
+  };
+
+  mkAttributes = jitSupport:
+    self.lib.mapAttrs' (version: path:
+      let
+        attrName = if jitSupport then "${version}_jit" else version;
+      in
+      self.lib.nameValuePair attrName (import path {
+        inherit jitSupport self;
+      })
+    ) versions;
+
+in
+# variations without and with JIT
+(mkAttributes false) // (mkAttributes true)

--- a/nix/postgresql/generic.nix
+++ b/nix/postgresql/generic.nix
@@ -1,0 +1,311 @@
+let
+
+  generic =
+      # dependencies
+      { stdenv, lib, fetchurl, makeWrapper
+      , glibc, zlib, readline, openssl, icu, lz4, zstd, systemd, libossp_uuid
+      , pkg-config, libxml2, tzdata, libkrb5, substituteAll, darwin
+      , linux-pam
+      , bison, flex, perl, docbook_xml_dtd_45, docbook-xsl-nons, libxslt
+
+      # This is important to obtain a version of `libpq` that does not depend on systemd.
+      , systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd && !stdenv.hostPlatform.isStatic
+      , enableSystemd ? null
+      , gssSupport ? with stdenv.hostPlatform; !isWindows && !isStatic
+
+      # for postgresql.pkgs
+      , self, newScope, buildEnv
+
+      # source specification
+      , version, hash, muslPatches ? {}
+
+      # for tests
+      , testers, nixosTests
+
+      # JIT
+      , jitSupport
+      , nukeReferences, patchelf, llvmPackages
+
+      # PL/Python
+      , pythonSupport ? false
+      , python3
+
+      # detection of crypt fails when using llvm stdenv, so we add it manually
+      # for <13 (where it got removed: https://github.com/postgres/postgres/commit/c45643d618e35ec2fe91438df15abd4f3c0d85ca)
+      , libxcrypt
+    } @args:
+  let
+    atLeast = lib.versionAtLeast version;
+    olderThan = lib.versionOlder version;
+    lz4Enabled = atLeast "14";
+    zstdEnabled = atLeast "15";
+
+    systemdSupport' = if enableSystemd == null then systemdSupport else (lib.warn "postgresql: argument enableSystemd is deprecated, please use systemdSupport instead." enableSystemd);
+
+    pname = "postgresql";
+
+    stdenv' = if jitSupport then llvmPackages.stdenv else stdenv;
+  in stdenv'.mkDerivation (finalAttrs: {
+    inherit version;
+    pname = pname + lib.optionalString jitSupport "-jit";
+
+    src = fetchurl {
+      url = "mirror://postgresql/source/v${version}/${pname}-${version}.tar.bz2";
+      inherit hash;
+    };
+
+    hardeningEnable = lib.optionals (!stdenv'.cc.isClang) [ "pie" ];
+
+    outputs = [ "out" "lib" "doc" "man" ];
+    setOutputFlags = false; # $out retains configureFlags :-/
+
+    buildInputs = [
+      zlib
+      readline
+      openssl
+      libxml2
+      icu
+    ]
+      ++ lib.optionals (olderThan "13") [ libxcrypt ]
+      ++ lib.optionals jitSupport [ llvmPackages.llvm ]
+      ++ lib.optionals lz4Enabled [ lz4 ]
+      ++ lib.optionals zstdEnabled [ zstd ]
+      ++ lib.optionals systemdSupport' [ systemd ]
+      ++ lib.optionals pythonSupport [ python3 ]
+      ++ lib.optionals gssSupport [ libkrb5 ]
+      ++ lib.optionals stdenv'.isLinux [ linux-pam ]
+      ++ lib.optionals (!stdenv'.isDarwin) [ libossp_uuid ];
+
+    nativeBuildInputs = [
+      makeWrapper
+      pkg-config
+    ]
+    ++ lib.optionals jitSupport [ llvmPackages.llvm.dev nukeReferences patchelf ]
+    ++ lib.optionals (atLeast "17") [ bison flex perl docbook_xml_dtd_45 docbook-xsl-nons libxslt ];
+
+    enableParallelBuilding = true;
+
+    separateDebugInfo = true;
+
+    buildFlags = [ "world" ];
+
+    # Makes cross-compiling work when xml2-config can't be executed on the host.
+    # Fixed upstream in https://github.com/postgres/postgres/commit/0bc8cebdb889368abdf224aeac8bc197fe4c9ae6
+    env.NIX_CFLAGS_COMPILE = lib.optionalString (olderThan "13") "-I${libxml2.dev}/include/libxml2";
+
+    configureFlags = [
+      "--with-openssl"
+      "--with-libxml"
+      "--with-icu"
+      "--sysconfdir=/etc"
+      "--libdir=$(lib)/lib"
+      "--with-system-tzdata=${tzdata}/share/zoneinfo"
+      "--enable-debug"
+      (lib.optionalString systemdSupport' "--with-systemd")
+      (if stdenv'.isDarwin then "--with-uuid=e2fs" else "--with-ossp-uuid")
+    ] ++ lib.optionals lz4Enabled [ "--with-lz4" ]
+      ++ lib.optionals zstdEnabled [ "--with-zstd" ]
+      ++ lib.optionals gssSupport [ "--with-gssapi" ]
+      ++ lib.optionals pythonSupport [ "--with-python" ]
+      ++ lib.optionals jitSupport [ "--with-llvm" ]
+      ++ lib.optionals stdenv'.isLinux [ "--with-pam" ];
+
+    patches = [
+      (if atLeast "16" then ./patches/relative-to-symlinks-16+.patch else ./patches/relative-to-symlinks.patch)
+      ./patches/less-is-more.patch
+      ./patches/paths-for-split-outputs.patch
+      ./patches/specify_pkglibdir_at_runtime.patch
+      ./patches/paths-with-postgresql-suffix.patch
+
+      (substituteAll {
+        src = ./patches/locale-binary-path.patch;
+        locale = "${if stdenv.isDarwin then darwin.adv_cmds else lib.getBin stdenv.cc.libc}/bin/locale";
+      })
+
+    ] ++ lib.optionals stdenv'.hostPlatform.isMusl (
+      # Using fetchurl instead of fetchpatch on purpose: https://github.com/NixOS/nixpkgs/issues/240141
+      map fetchurl (lib.attrValues muslPatches)
+    ) ++ lib.optionals stdenv'.isLinux  [
+      (if atLeast "13" then ./patches/socketdir-in-run-13+.patch else ./patches/socketdir-in-run.patch)
+    ];
+
+    installTargets = [ "install-world" ];
+
+    postPatch = ''
+      # Hardcode the path to pgxs so pg_config returns the path in $out
+      substituteInPlace "src/common/config_info.c" --subst-var out
+    '' + lib.optionalString jitSupport ''
+        # Force lookup of jit stuff in $out instead of $lib
+        substituteInPlace src/backend/jit/jit.c --replace pkglib_path \"$out/lib\"
+        substituteInPlace src/backend/jit/llvm/llvmjit.c --replace pkglib_path \"$out/lib\"
+        substituteInPlace src/backend/jit/llvm/llvmjit_inline.cpp --replace pkglib_path \"$out/lib\"
+    '';
+
+    postInstall =
+      ''
+        moveToOutput "lib/pgxs" "$out" # looks strange, but not deleting it
+        moveToOutput "lib/libpgcommon*.a" "$out"
+        moveToOutput "lib/libpgport*.a" "$out"
+        moveToOutput "lib/libecpg*" "$out"
+
+        # Prevent a retained dependency on gcc-wrapper.
+        substituteInPlace "$out/lib/pgxs/src/Makefile.global" --replace ${stdenv'.cc}/bin/ld ld
+
+        if [ -z "''${dontDisableStatic:-}" ]; then
+          # Remove static libraries in case dynamic are available.
+          for i in $out/lib/*.a $lib/lib/*.a; do
+            name="$(basename "$i")"
+            ext="${stdenv'.hostPlatform.extensions.sharedLibrary}"
+            if [ -e "$lib/lib/''${name%.a}$ext" ] || [ -e "''${i%.a}$ext" ]; then
+              rm "$i"
+            fi
+          done
+        fi
+      '' + lib.optionalString jitSupport ''
+        # Move the bitcode and libllvmjit.so library out of $lib; otherwise, every client that
+        # depends on libpq.so will also have libLLVM.so in its closure too, bloating it
+        moveToOutput "lib/bitcode" "$out"
+        moveToOutput "lib/llvmjit*" "$out"
+
+        # In the case of JIT support, prevent a retained dependency on clang-wrapper
+        substituteInPlace "$out/lib/pgxs/src/Makefile.global" --replace ${stdenv'.cc}/bin/clang clang
+        nuke-refs $out/lib/llvmjit_types.bc $(find $out/lib/bitcode -type f)
+
+        # Stop out depending on the default output of llvm
+        substituteInPlace $out/lib/pgxs/src/Makefile.global \
+          --replace ${llvmPackages.llvm.out}/bin "" \
+          --replace '$(LLVM_BINPATH)/' ""
+
+        # Stop out depending on the -dev output of llvm
+        substituteInPlace $out/lib/pgxs/src/Makefile.global \
+          --replace ${llvmPackages.llvm.dev}/bin/llvm-config llvm-config \
+          --replace -I${llvmPackages.llvm.dev}/include ""
+
+        ${lib.optionalString (!stdenv'.isDarwin) ''
+          # Stop lib depending on the -dev output of llvm
+          rpath=$(patchelf --print-rpath $out/lib/llvmjit.so)
+          nuke-refs -e $out $out/lib/llvmjit.so
+          # Restore the correct rpath
+          patchelf $out/lib/llvmjit.so --set-rpath "$rpath"
+        ''}
+      '';
+
+    postFixup = lib.optionalString (!stdenv'.isDarwin && stdenv'.hostPlatform.libc == "glibc")
+      ''
+        # initdb needs access to "locale" command from glibc.
+        wrapProgram $out/bin/initdb --prefix PATH ":" ${glibc.bin}/bin
+      '';
+
+    doCheck = !stdenv'.isDarwin;
+    # autodetection doesn't seem to able to find this, but it's there.
+    checkTarget = "check";
+
+    disallowedReferences = [ stdenv'.cc ];
+
+    passthru = let
+      this = self.callPackage generic args;
+      jitToggle = this.override {
+        jitSupport = !jitSupport;
+      };
+    in
+    {
+      psqlSchema = lib.versions.major version;
+
+      withJIT = if jitSupport then this else jitToggle;
+      withoutJIT = if jitSupport then jitToggle else this;
+
+      dlSuffix = if olderThan "16" then ".so" else stdenv.hostPlatform.extensions.sharedLibrary;
+
+      pkgs = let
+        scope = {
+          inherit jitSupport;
+          inherit (llvmPackages) llvm;
+          postgresql = this;
+          stdenv = stdenv';
+        };
+        newSelf = self // scope;
+        newSuper = { callPackage = newScope (scope // this.pkgs); };
+      in import ./ext newSelf newSuper;
+
+      withPackages = postgresqlWithPackages {
+                       inherit makeWrapper buildEnv;
+                       postgresql = this;
+                     }
+                     this.pkgs;
+
+      tests = {
+        postgresql-wal-receiver = import ../../../../nixos/tests/postgresql-wal-receiver.nix {
+          inherit (stdenv) system;
+          pkgs = self;
+          package = this;
+        };
+        pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      } // lib.optionalAttrs jitSupport {
+        postgresql-jit = import ../../../../nixos/tests/postgresql-jit.nix {
+          inherit (stdenv) system;
+          pkgs = self;
+          package = this;
+        };
+      };
+    };
+
+    meta = with lib; {
+      homepage    = "https://www.postgresql.org";
+      description = "Powerful, open source object-relational database system";
+      license     = licenses.postgresql;
+      changelog   = "https://www.postgresql.org/docs/release/${finalAttrs.version}/";
+      maintainers = with maintainers; [ thoughtpolice danbst globin ivan ma27 wolfgangwalther ];
+      pkgConfigModules = [ "libecpg" "libecpg_compat" "libpgtypes" "libpq" ];
+      platforms   = platforms.unix;
+
+      # JIT support doesn't work with cross-compilation. It is attempted to build LLVM-bytecode
+      # (`%.bc` is the corresponding `make(1)`-rule) for each sub-directory in `backend/` for
+      # the JIT apparently, but with a $(CLANG) that can produce binaries for the build, not the
+      # host-platform.
+      #
+      # I managed to get a cross-build with JIT support working with
+      # `depsBuildBuild = [ llvmPackages.clang ] ++ buildInputs`, but considering that the
+      # resulting LLVM IR isn't platform-independent this doesn't give you much.
+      # In fact, I tried to test the result in a VM-test, but as soon as JIT was used to optimize
+      # a query, postgres would coredump with `Illegal instruction`.
+      broken = (jitSupport && stdenv.hostPlatform != stdenv.buildPlatform)
+        # Allmost all tests fail FATAL errors for v12 and v13
+        || (jitSupport && stdenv.hostPlatform.isMusl && olderThan "14");
+    };
+  });
+
+  postgresqlWithPackages = { postgresql, makeWrapper, buildEnv }: pkgs: f: buildEnv {
+    name = "postgresql-and-plugins-${postgresql.version}";
+    paths = f pkgs ++ [
+        postgresql
+        postgresql.lib
+        postgresql.man   # in case user installs this into environment
+    ];
+    nativeBuildInputs = [ makeWrapper ];
+
+
+    # We include /bin to ensure the $out/bin directory is created, which is
+    # needed because we'll be removing the files from that directory in postBuild
+    # below. See #22653
+    pathsToLink = ["/" "/bin"];
+
+    # Note: the duplication of executables is about 4MB size.
+    # So a nicer solution was patching postgresql to allow setting the
+    # libdir explicitly.
+    postBuild = ''
+      mkdir -p $out/bin
+      rm $out/bin/{pg_config,postgres,pg_ctl}
+      cp --target-directory=$out/bin ${postgresql}/bin/{postgres,pg_config,pg_ctl}
+      wrapProgram $out/bin/postgres --set NIX_PGLIBDIR $out/lib
+    '';
+
+    passthru.version = postgresql.version;
+    passthru.psqlSchema = postgresql.psqlSchema;
+  };
+
+in
+# passed by <major>.nix
+versionArgs:
+# passed by default.nix
+{ self, ... } @defaultArgs:
+self.callPackage generic (defaultArgs // versionArgs)

--- a/nix/postgresql/patches/less-is-more.patch
+++ b/nix/postgresql/patches/less-is-more.patch
@@ -1,0 +1,11 @@
+--- a/src/include/fe_utils/print.h
++++ b/src/include/fe_utils/print.h
+@@ -18,7 +18,7 @@
+ 
+ /* This is not a particularly great place for this ... */
+ #ifndef __CYGWIN__
+-#define DEFAULT_PAGER "more"
++#define DEFAULT_PAGER "less"
+ #else
+ #define DEFAULT_PAGER "less"
+ #endif

--- a/nix/postgresql/patches/locale-binary-path.patch
+++ b/nix/postgresql/patches/locale-binary-path.patch
@@ -1,0 +1,11 @@
+--- a/src/backend/commands/collationcmds.c
++++ b/src/backend/commands/collationcmds.c
+@@ -611,7 +611,7 @@ pg_import_system_collations(PG_FUNCTION_ARGS)
+ 		aliases = (CollAliasData *) palloc(maxaliases * sizeof(CollAliasData));
+ 		naliases = 0;
+ 
+-		locale_a_handle = OpenPipeStream("locale -a", "r");
++		locale_a_handle = OpenPipeStream("@locale@ -a", "r");
+ 		if (locale_a_handle == NULL)
+ 			ereport(ERROR,
+ 					(errcode_for_file_access(),

--- a/nix/postgresql/patches/paths-for-split-outputs.patch
+++ b/nix/postgresql/patches/paths-for-split-outputs.patch
@@ -1,0 +1,11 @@
+--- a/src/common/config_info.c
++++ b/src/common/config_info.c
+@@ -118,7 +118,7 @@
+ 	i++;
+
+ 	configdata[i].name = pstrdup("PGXS");
++	strlcpy(path, "@out@/lib", sizeof(path));
+-	get_pkglib_path(my_exec_path, path);
+ 	strlcat(path, "/pgxs/src/makefiles/pgxs.mk", sizeof(path));
+ 	cleanup_path(path);
+ 	configdata[i].setting = pstrdup(path);

--- a/nix/postgresql/patches/paths-with-postgresql-suffix.patch
+++ b/nix/postgresql/patches/paths-with-postgresql-suffix.patch
@@ -1,0 +1,41 @@
+Nix outputs put the `name' in each store path like
+/nix/store/...-<name>. This was confusing the Postgres make script
+because it thought its data directory already had postgresql in its
+directory. This lead to Postgres installing all of its fils in
+$out/share. To fix this, we just look for postgres or psql in the part
+after the / using make's notdir.
+
+---
+--- a/src/Makefile.global.in
++++ b/src/Makefile.global.in
+@@ -102,15 +102,15 @@ datarootdir := @datarootdir@
+ bindir := @bindir@
+ 
+ datadir := @datadir@
+-ifeq "$(findstring pgsql, $(datadir))" ""
+-ifeq "$(findstring postgres, $(datadir))" ""
++ifeq "$(findstring pgsql, $(notdir $(datadir)))" ""
++ifeq "$(findstring postgres, $(notdir $(datadir)))" ""
+ override datadir := $(datadir)/postgresql
+ endif
+ endif
+ 
+ sysconfdir := @sysconfdir@
+-ifeq "$(findstring pgsql, $(sysconfdir))" ""
+-ifeq "$(findstring postgres, $(sysconfdir))" ""
++ifeq "$(findstring pgsql, $(notdir $(sysconfdir)))" ""
++ifeq "$(findstring postgres, $(notdir $(sysconfdir)))" ""
+ override sysconfdir := $(sysconfdir)/postgresql
+ endif
+ endif
+@@ -136,8 +136,8 @@ endif
+ mandir := @mandir@
+ 
+ docdir := @docdir@
+-ifeq "$(findstring pgsql, $(docdir))" ""
+-ifeq "$(findstring postgres, $(docdir))" ""
++ifeq "$(findstring pgsql, $(notdir $(docdir)))" ""
++ifeq "$(findstring postgres, $(notdir $(docdir)))" ""
+ override docdir := $(docdir)/postgresql
+ endif
+ endif

--- a/nix/postgresql/patches/relative-to-symlinks-16+.patch
+++ b/nix/postgresql/patches/relative-to-symlinks-16+.patch
@@ -1,0 +1,13 @@
+On NixOS we *want* stuff relative to symlinks.
+---
+--- a/src/common/exec.c
++++ b/src/common/exec.c
+@@ -238,6 +238,8 @@
+ static int
+ normalize_exec_path(char *path)
+ {
++	return 0;
++
+ 	/*
+ 	 * We used to do a lot of work ourselves here, but now we just let
+ 	 * realpath(3) do all the heavy lifting.

--- a/nix/postgresql/patches/relative-to-symlinks.patch
+++ b/nix/postgresql/patches/relative-to-symlinks.patch
@@ -1,0 +1,13 @@
+On NixOS we *want* stuff relative to symlinks.
+---
+--- a/src/common/exec.c
++++ b/src/common/exec.c
+@@ -218,6 +218,8 @@
+ static int
+ resolve_symlinks(char *path)
+ {
++	return 0;
++
+ #ifdef HAVE_READLINK
+ 	struct stat buf;
+ 	char		orig_wd[MAXPGPATH],

--- a/nix/postgresql/patches/socketdir-in-run-13+.patch
+++ b/nix/postgresql/patches/socketdir-in-run-13+.patch
@@ -1,0 +1,11 @@
+--- a/src/include/pg_config_manual.h
++++ b/src/include/pg_config_manual.h
+@@ -201,7 +201,7 @@
+  * support them yet.
+  */
+ #ifndef WIN32
+-#define DEFAULT_PGSOCKET_DIR  "/tmp"
++#define DEFAULT_PGSOCKET_DIR  "/run/postgresql"
+ #else
+ #define DEFAULT_PGSOCKET_DIR ""
+ #endif

--- a/nix/postgresql/patches/socketdir-in-run.patch
+++ b/nix/postgresql/patches/socketdir-in-run.patch
@@ -1,0 +1,11 @@
+--- a/src/include/pg_config_manual.h
++++ b/src/include/pg_config_manual.h
+@@ -179,7 +179,7 @@
+  * here's where to twiddle it.  You can also override this at runtime
+  * with the postmaster's -k switch.
+  */
+-#define DEFAULT_PGSOCKET_DIR  "/tmp"
++#define DEFAULT_PGSOCKET_DIR  "/run/postgresql"
+ 
+ /*
+  * This is the default event source for Windows event log.

--- a/nix/postgresql/patches/specify_pkglibdir_at_runtime.patch
+++ b/nix/postgresql/patches/specify_pkglibdir_at_runtime.patch
@@ -1,0 +1,28 @@
+--- a/src/port/path.c
++++ b/src/port/path.c
+@@ -714,7 +714,11 @@
+ void
+ get_lib_path(const char *my_exec_path, char *ret_path)
+ {
+-	make_relative_path(ret_path, LIBDIR, PGBINDIR, my_exec_path);
++	char const * const nix_pglibdir = getenv("NIX_PGLIBDIR");
++	if(nix_pglibdir == NULL)
++		make_relative_path(ret_path, LIBDIR, PGBINDIR, my_exec_path);
++	else
++		make_relative_path(ret_path, nix_pglibdir, PGBINDIR, my_exec_path);
+ }
+ 
+ /*
+@@ -723,7 +727,11 @@
+ void
+ get_pkglib_path(const char *my_exec_path, char *ret_path)
+ {
+-	make_relative_path(ret_path, PKGLIBDIR, PGBINDIR, my_exec_path);
++	char const * const nix_pglibdir = getenv("NIX_PGLIBDIR");
++	if(nix_pglibdir == NULL)
++		make_relative_path(ret_path, PKGLIBDIR, PGBINDIR, my_exec_path);
++	else
++		make_relative_path(ret_path, nix_pglibdir, PGBINDIR, my_exec_path);
+ }
+ 
+ /*

--- a/nix/postgresql/pg_config.sh
+++ b/nix/postgresql/pg_config.sh
@@ -1,0 +1,35 @@
+# The real pg_config needs to be in the same path as the "postgres" binary
+# to return proper paths. However, we want it in the -dev output to prevent
+# cyclic references and to prevent blowing up the runtime closure. Thus, we
+# have wrapped -dev/bin/pg_config to fake its argv0 to be in the default
+# output. Unfortunately, pg_config tries to be smart and tries to find itself -
+# which will then fail with:
+#   pg_config: could not find own program executable
+# To counter this, we're creating *this* fake pg_config script and put it into
+# the default output. The real pg_config is happy.
+# Some extensions, e.g. timescaledb, use the reverse logic and look for pg_config
+# in the same path as the "postgres" binary to support multi-version-installs.
+# Thus, they will end up calling this script during build, even though the real
+# pg_config would be available on PATH, provided by nativeBuildInputs. To help
+# this case, we're redirecting the call to pg_config to the one found in PATH,
+# iff we can be convinced that it belongs to our -dev output.
+
+# Avoid infinite recursion
+if [[ ! -v PG_CONFIG_CALLED ]]; then
+    # compares "path of *this* script" with "path, which pg_config on PATH believes it is in"
+    if [[ "$(readlink -f -- "$0")" == "$(PG_CONFIG_CALLED=1 pg_config --bindir)/pg_config" ]]; then
+        # The pg_config in PATH returns the same bindir that we're actually called from.
+        # This means that the pg_config in PATH is the one from "our" -dev output.
+        # This happens when the -dev output has been put in native build
+        # inputs and allows us to call the real pg_config without referencing
+        # the -dev output itself.
+        exec pg_config "$@"
+    fi
+fi
+
+# This will happen in one of these cases:
+# - *this* script is the first on PATH
+# - np pg_config on PATH
+# - some other pg_config on PATH, not from our -dev output
+echo The real pg_config can be found in the -dev output.
+exit 1

--- a/shell.nix
+++ b/shell.nix
@@ -1,15 +1,24 @@
 with import (builtins.fetchTarball {
-  name = "23.11";
-  url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/23.11.tar.gz";
-  sha256 = "1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k";
+  name = "24.05";
+  url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/24.05.tar.gz";
+  sha256 = "sha256:1lr1h35prqkd1mkmzriwlpvxcb34kmhc9dnr48gkm8hh089hifmx";
 }) {};
 let
+  ourPg = callPackage ./nix/postgresql/default.nix {
+    inherit lib;
+    inherit stdenv;
+    inherit fetchurl;
+    inherit makeWrapper;
+    inherit callPackage;
+  };
   supportedPgVersions = [
     postgresql_13
     postgresql_14
     postgresql_15
     postgresql_16
+    ourPg.postgresql_17
   ];
+
   pgWithExt = { postgresql }: postgresql.withPackages (p: [
     (callPackage ./nix/supautils.nix { inherit postgresql; extraMakeFlags = "TEST=1"; })
     (callPackage ./nix/pg_tle.nix { inherit postgresql; })
@@ -17,5 +26,7 @@ let
   pgScriptAll = map (x: callPackage ./nix/pgScript.nix { postgresql = pgWithExt { postgresql = x;}; }) supportedPgVersions;
 in
 mkShell {
-  buildInputs = [ pgScriptAll ];
+  buildInputs = [
+    pgScriptAll
+  ];
 }

--- a/src/constrained_extensions.c
+++ b/src/constrained_extensions.c
@@ -163,7 +163,7 @@ parse_constrained_extensions(
 
 	json_constrained_extension_parse_state state = {JCE_EXPECT_TOPLEVEL_START, NULL, 0, cexts};
 
-	lex = makeJsonLexContextCstringLen(pstrdup(str), strlen(str), PG_UTF8, true);
+	lex = NEW_JSON_LEX_CONTEXT_CSTRING_LEN(pstrdup(str), strlen(str), PG_UTF8, true);
 
 	sem.semstate = &state;
 	sem.object_start = json_object_start;

--- a/src/drop_trigger_grants.c
+++ b/src/drop_trigger_grants.c
@@ -137,7 +137,7 @@ parse_drop_trigger_grants(const char *str, drop_trigger_grants *dtgs) {
                                                   NULL, 0, dtgs};
 
     lex =
-        makeJsonLexContextCstringLen(pstrdup(str), strlen(str), PG_UTF8, true);
+        NEW_JSON_LEX_CONTEXT_CSTRING_LEN(pstrdup(str), strlen(str), PG_UTF8, true);
 
     sem.semstate = &state;
     sem.object_start = json_object_start;

--- a/src/extensions_parameter_overrides.c
+++ b/src/extensions_parameter_overrides.c
@@ -118,7 +118,7 @@ parse_extensions_parameter_overrides(const char *str,
         JEPO_EXPECT_TOPLEVEL_START, NULL, 0, epos};
 
     lex =
-        makeJsonLexContextCstringLen(pstrdup(str), strlen(str), PG_UTF8, true);
+        NEW_JSON_LEX_CONTEXT_CSTRING_LEN(pstrdup(str), strlen(str), PG_UTF8, true);
 
     sem.semstate = &state;
     sem.object_start = json_object_start;

--- a/src/policy_grants.c
+++ b/src/policy_grants.c
@@ -137,7 +137,7 @@ json_policy_grants_parse_state parse_policy_grants(const char *str,
                                             pgs};
 
     lex =
-        makeJsonLexContextCstringLen(pstrdup(str), strlen(str), PG_UTF8, true);
+        NEW_JSON_LEX_CONTEXT_CSTRING_LEN(pstrdup(str), strlen(str), PG_UTF8, true);
 
     sem.semstate = &state;
     sem.object_start = json_object_start;

--- a/src/utils.h
+++ b/src/utils.h
@@ -15,6 +15,19 @@
 #define PG14_GTE (PG_VERSION_NUM >= 140000)
 #define PG15_GTE (PG_VERSION_NUM >= 150000)
 #define PG16_GTE (PG_VERSION_NUM >= 160000)
+#define PG17_GTE (PG_VERSION_NUM >= 170000)
+
+#if PG17_GTE
+
+#define NEW_JSON_LEX_CONTEXT_CSTRING_LEN(a, b, c, d) \
+  makeJsonLexContextCstringLen(NULL, a, b, c, d)
+
+#else
+
+#define NEW_JSON_LEX_CONTEXT_CSTRING_LEN(a, b, c, d) \
+  makeJsonLexContextCstringLen(a, b, c, d)
+
+#endif
 
 #if PG16_GTE
 


### PR DESCRIPTION
In pg 17, `makeJsonLexContextCstringLen` changed its signature.

From:

```c
JsonLexContext * makeJsonLexContextCstringLen(const char *json, size_t len, int encoding, bool need_escapes)
```

To:

```c
JsonLexContext * makeJsonLexContextCstringLen(JsonLexContext *lex, const char *json, size_t len, int encoding, bool need_escapes)
```