### PR TITLE
feat: allow changing extension schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
 GREP ?= grep
 PG_CONFIG = pg_config
 
+PG_CFLAGS = -std=c99 -Wall -Werror -Wno-declaration-after-statement
 ifeq ($(TEST), 1)
-	PG_CFLAGS = -Wall -Werror -DTEST
-else
-	PG_CFLAGS = -Wall -Werror
+	PG_CFLAGS += -DTEST
 endif
 
 MODULE_big = supautils

--- a/nix/withTmpDb.sh.in
+++ b/nix/withTmpDb.sh.in
@@ -17,7 +17,7 @@ options="-F -c listen_addresses=\"\" -k $PGDATA -c shared_preload_libraries=\"pg
 
 reserved_roles="supabase_storage_admin, anon, reserved_but_not_yet_created, authenticator*"
 reserved_memberships="pg_read_server_files, pg_write_server_files, pg_execute_server_program, role_with_reserved_membership"
-privileged_extensions="autoinc, citext, hstore, sslinfo, pg_tle, postgres_fdw"
+privileged_extensions="autoinc, citext, hstore, sslinfo, pg_tle, postgres_fdw, pageinspect"
 privileged_extensions_custom_scripts_path="$tmpdir/privileged_extensions_custom_scripts"
 privileged_role="privileged_role"
 privileged_role_allowed_configs="session_replication_role, pgrst.*, other.nested.*"

--- a/src/privileged_extensions.c
+++ b/src/privileged_extensions.c
@@ -272,11 +272,11 @@ void handle_create_extension(
 
 void handle_alter_extension(
     void (*process_utility_hook)(PROCESS_UTILITY_PARAMS),
-    PROCESS_UTILITY_PARAMS, const char *privileged_extensions,
+    PROCESS_UTILITY_PARAMS,
+    const char *extname, const char *privileged_extensions,
     const char *privileged_extensions_superuser) {
-    AlterExtensionStmt *stmt = (AlterExtensionStmt *)pstmt->utilityStmt;
 
-    if (is_string_in_comma_delimited_string(stmt->extname,
+    if (is_string_in_comma_delimited_string(extname,
                                             privileged_extensions)) {
         bool already_switched_to_superuser = false;
         switch_to_superuser(privileged_extensions_superuser,

--- a/src/privileged_extensions.h
+++ b/src/privileged_extensions.h
@@ -14,6 +14,7 @@ extern void handle_create_extension(
 extern void
 handle_alter_extension(void (*process_utility_hook)(PROCESS_UTILITY_PARAMS),
                        PROCESS_UTILITY_PARAMS,
+                       const char *extname,
                        const char *privileged_extensions,
                        const char *privileged_extensions_superuser);
 

--- a/test/expected/privileged_extensions.out
+++ b/test/expected/privileged_extensions.out
@@ -104,3 +104,31 @@ drop role another_superuser;
 set role extensions_role;
 \echo
 
+-- can change extensions schema
+create extension pageinspect;
+select count(*) = 3 as extensions_in_public_schema
+from information_schema.routines
+where routine_name in ('page_header', 'heap_page_items', 'bt_metap')
+and routine_schema = 'public';
+ extensions_in_public_schema 
+-----------------------------
+ t
+(1 row)
+
+-- go back to postgres role for creating a new schema and switch to extensions_role again
+reset role;
+create schema xtens;
+set role extensions_role;
+\echo
+
+-- now alter extension schema
+alter extension pageinspect set schema xtens;
+select count(*) = 3 as extensions_in_xtens_schema
+from information_schema.routines
+where routine_name in ('page_header', 'heap_page_items', 'bt_metap')
+and routine_schema = 'xtens';
+ extensions_in_xtens_schema 
+----------------------------
+ t
+(1 row)
+

--- a/test/expected/privileged_extensions.out
+++ b/test/expected/privileged_extensions.out
@@ -1,7 +1,3 @@
--- non-superuser extensions role
-create role extensions_role login;
-grant all on database postgres to extensions_role;
-alter default privileges for role postgres in schema public grant all on tables to extensions_role;
 set role extensions_role;
 \echo
 

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -19,3 +19,8 @@ grant testme to privileged_role with admin option;
 create role authenticator login noinherit;
 grant authenticator to privileged_role with admin option;
 grant all on database postgres to privileged_role;
+
+-- non-superuser extensions role
+create role extensions_role login nosuperuser;
+grant all on database postgres to extensions_role;
+alter default privileges for role postgres in schema public grant all on tables to extensions_role;

--- a/test/sql/privileged_extensions.sql
+++ b/test/sql/privileged_extensions.sql
@@ -67,3 +67,25 @@ drop extension sslinfo;
 drop role another_superuser;
 set role extensions_role;
 \echo
+
+-- can change extensions schema
+create extension pageinspect;
+
+select count(*) = 3 as extensions_in_public_schema
+from information_schema.routines
+where routine_name in ('page_header', 'heap_page_items', 'bt_metap')
+and routine_schema = 'public';
+
+-- go back to postgres role for creating a new schema and switch to extensions_role again
+reset role;
+create schema xtens;
+set role extensions_role;
+\echo
+
+-- now alter extension schema
+alter extension pageinspect set schema xtens;
+
+select count(*) = 3 as extensions_in_xtens_schema
+from information_schema.routines
+where routine_name in ('page_header', 'heap_page_items', 'bt_metap')
+and routine_schema = 'xtens';

--- a/test/sql/privileged_extensions.sql
+++ b/test/sql/privileged_extensions.sql
@@ -1,7 +1,3 @@
--- non-superuser extensions role
-create role extensions_role login;
-grant all on database postgres to extensions_role;
-alter default privileges for role postgres in schema public grant all on tables to extensions_role;
 set role extensions_role;
 \echo
 


### PR DESCRIPTION
Current logic doesn't capture the `ALTER EXTENSION .. SET SCHEMA` statement.

This uses the `pageinspect` contrib extension for testing.

Closes https://github.com/supabase/supautils/issues/88.