### PR TITLE
feat: support non-superuser event trigger

### DIFF
--- a/src/pg_prelude.h
+++ b/src/pg_prelude.h
@@ -24,6 +24,7 @@
 #include <utils/json.h>
 #include <utils/jsonb.h>
 #include <utils/jsonfuncs.h>
+#include <utils/lsyscache.h>
 #include <utils/memutils.h>
 #include <utils/regproc.h>
 #include <utils/snapmgr.h>

--- a/src/utils.h
+++ b/src/utils.h
@@ -50,6 +50,8 @@
 #define PROCESS_UTILITY_ARGS                                                   \
     pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, qc
 
+#define SUPAUTILS_EVENT_TRIGGER_OID EVENT_TRIGGEROID
+
 #else // PG13
 
 #define PROCESS_UTILITY_PARAMS                                                 \
@@ -58,6 +60,8 @@
         QueryEnvironment *queryEnv, DestReceiver *dest, QueryCompletion *qc
 #define PROCESS_UTILITY_ARGS                                                   \
     pstmt, queryString, context, params, queryEnv, dest, qc
+
+#define SUPAUTILS_EVENT_TRIGGER_OID EVTTRIGGEROID
 
 #endif
 

--- a/test/expected/event_triggers.out
+++ b/test/expected/event_triggers.out
@@ -1,0 +1,66 @@
+create or replace function show_current_user()
+    returns event_trigger
+    language plpgsql as
+$$
+begin
+    raise notice 'the event trigger is executed for %', current_user;
+end;
+$$;
+grant all on schema public to privileged_role;
+grant all on schema public to rolecreator;
+grant all on schema public to supabase_storage_admin;
+set role rolecreator;
+\echo
+
+-- A role other than privileged_role shouldn't be able to create the event trigger
+create event trigger event_trigger_1 on ddl_command_end
+execute procedure show_current_user();
+ERROR:  permission denied to create event trigger "event_trigger_1"
+HINT:  Must be superuser to create an event trigger.
+\echo
+
+set role privileged_role;
+\echo
+
+-- The privileged_role should be able to create the event trigger
+create event trigger event_trigger_1 on ddl_command_end
+execute procedure show_current_user();
+\echo
+
+-- The privileged_role should execute the event trigger function
+create table privileged_stuff();
+NOTICE:  the event trigger is executed for privileged_role
+\echo
+
+set role rolecreator;
+\echo
+
+-- A role other than privileged_role should execute the event trigger function
+create function dummy() returns text as $$ select 'dummy'; $$ language sql;
+NOTICE:  the event trigger is executed for rolecreator
+\echo
+
+set role supabase_storage_admin;
+\echo
+
+-- A reserved_role shouldn't execute the event trigger function
+create table storage_stuff();
+WARNING:  Skipping event trigger
+\echo
+
+drop table storage_stuff;
+WARNING:  Skipping event trigger
+\echo
+
+set role postgres;
+\echo
+
+-- A superuser role shouldn't execute the event trigger function
+create table super_stuff();
+WARNING:  Skipping event trigger
+\echo
+
+drop event trigger event_trigger_1;
+revoke all on schema public from privileged_role;
+revoke all on schema public from rolecreator;
+revoke all on schema public from supabase_storage_admin;

--- a/test/sql/event_triggers.sql
+++ b/test/sql/event_triggers.sql
@@ -1,0 +1,61 @@
+create or replace function show_current_user()
+    returns event_trigger
+    language plpgsql as
+$$
+begin
+    raise notice 'the event trigger is executed for %', current_user;
+end;
+$$;
+
+grant all on schema public to privileged_role;
+grant all on schema public to rolecreator;
+grant all on schema public to supabase_storage_admin;
+
+set role rolecreator;
+\echo
+
+-- A role other than privileged_role shouldn't be able to create the event trigger
+create event trigger event_trigger_1 on ddl_command_end
+execute procedure show_current_user();
+\echo
+
+set role privileged_role;
+\echo
+
+-- The privileged_role should be able to create the event trigger
+create event trigger event_trigger_1 on ddl_command_end
+execute procedure show_current_user();
+\echo
+
+-- The privileged_role should execute the event trigger function
+create table privileged_stuff();
+\echo
+
+set role rolecreator;
+\echo
+
+-- A role other than privileged_role should execute the event trigger function
+create function dummy() returns text as $$ select 'dummy'; $$ language sql;
+\echo
+
+set role supabase_storage_admin;
+\echo
+
+-- A reserved_role shouldn't execute the event trigger function
+create table storage_stuff();
+\echo
+
+drop table storage_stuff;
+\echo
+
+set role postgres;
+\echo
+
+-- A superuser role shouldn't execute the event trigger function
+create table super_stuff();
+\echo
+
+drop event trigger event_trigger_1;
+revoke all on schema public from privileged_role;
+revoke all on schema public from rolecreator;
+revoke all on schema public from supabase_storage_admin;


### PR DESCRIPTION
Closes https://github.com/supabase/supautils/issues/67.

The `privileged_role` is able to switch to superuser to create event triggers.

To prevent privesc, superusers and `reserved_roles` skip event trigger execution.

Limitation: while doing `create extension` event triggers will not be fired, since extensions are created by a superuser.

## Implementation

It uses the `fmgr_hook` to skip event triggers. However note that `fmgr_hook` doesn't really offer a direct way to say "skip this function execution" (although we can abort with `ereport`), so to achieve this the workaround is to override the `FmgrInfo` and turn into a noop.