### PR TITLE
fix: not allowing to alter schema on non-extension

### DIFF
--- a/src/supautils.c
+++ b/src/supautils.c
@@ -425,24 +425,26 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
    * ALTER EXTENSION <extension> SET SCHEMA
    */
   case T_AlterObjectSchemaStmt: {
-      if (superuser()) {
-          break;
-      }
-      if (privileged_extensions == NULL) {
-          break;
-      }
-
       AlterObjectSchemaStmt *stmt = (AlterObjectSchemaStmt *)pstmt->utilityStmt;
 
       if (stmt->objectType == OBJECT_EXTENSION){
+          if (superuser()) {
+              break;
+          }
+          if (privileged_extensions == NULL) {
+              break;
+          }
+
           handle_alter_extension(prev_hook,
                                  PROCESS_UTILITY_ARGS,
                                  strVal(stmt->object),
                                  privileged_extensions,
                                  supautils_superuser);
+
+         return;
       }
 
-      return;
+      break;
   }
 
   /*

--- a/test/expected/privileged_extensions.out
+++ b/test/expected/privileged_extensions.out
@@ -132,3 +132,13 @@ and routine_schema = 'xtens';
  t
 (1 row)
 
+-- users can change tables schemas normally
+reset role;
+set role nonsuper;
+create table public.qux();
+create schema baz;
+alter table public.qux set schema baz;
+select * from baz.qux;
+--
+(0 rows)
+

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -24,3 +24,13 @@ grant all on database postgres to privileged_role;
 create role extensions_role login nosuperuser;
 grant all on database postgres to extensions_role;
 alter default privileges for role postgres in schema public grant all on tables to extensions_role;
+
+-- non-superuser that should be unaffected by extension logic when creating db objects
+create user nonsuper nosuperuser;
+grant all privileges on database contrib_regression to nonsuper;
+grant all on schema public to nonsuper;
+-- also allow on postgres db for quick manual tests
+\c postgres
+grant all on schema public to nonsuper;
+grant all privileges on database postgres to nonsuper;
+\c contrib_regression

--- a/test/sql/privileged_extensions.sql
+++ b/test/sql/privileged_extensions.sql
@@ -89,3 +89,12 @@ select count(*) = 3 as extensions_in_xtens_schema
 from information_schema.routines
 where routine_name in ('page_header', 'heap_page_items', 'bt_metap')
 and routine_schema = 'xtens';
+
+-- users can change tables schemas normally
+reset role;
+set role nonsuper;
+
+create table public.qux();
+create schema baz;
+alter table public.qux set schema baz;
+select * from baz.qux;


### PR DESCRIPTION
This bug was introduced by fcb20b39de2c56f066ac68066ffa4ea870d92d1a (https://github.com/supabase/supautils/pull/94)

Looks like it escaped review because of https://github.com/supabase/supautils/issues/79.