### PR TITLE
correct: do not log skipped event triggers

### DIFF
--- a/src/supautils.c
+++ b/src/supautils.c
@@ -118,7 +118,6 @@ static void supautils_fmgr_hook(FmgrHookEventType event, FmgrInfo *flinfo, Datum
     case FHET_START: {
         const char *current_role_name = GetUserNameFromId(GetUserId(), false);
         if (superuser() || is_reserved_role(current_role_name, false)) {
-            elog(WARNING, "Skipping event trigger");
             // we can't skip execution directly inside the fmgr_hook (although we can abort it with ereport)
             // so instead we change the event trigger function to a noop function
             force_noop(flinfo);

--- a/test/expected/event_triggers.out
+++ b/test/expected/event_triggers.out
@@ -56,11 +56,9 @@ set role supabase_storage_admin;
 
 -- A reserved_role shouldn't execute the event trigger function
 create table storage_stuff();
-WARNING:  Skipping event trigger
 \echo
 
 drop table storage_stuff;
-WARNING:  Skipping event trigger
 \echo
 
 -- A superuser role shouldn't execute the event trigger function
@@ -68,7 +66,6 @@ set role postgres;
 \echo
 
 create table super_stuff();
-WARNING:  Skipping event trigger
 \echo
 
 -- privesc shouldn't happen due to superuser tripping over a user-defined event trigger
@@ -77,15 +74,22 @@ execute procedure become_super();
 \echo
 
 create table super_duper_stuff();
-WARNING:  Skipping event trigger
-WARNING:  Skipping event trigger
 select count(*) = 1 as only_one_super from pg_roles where rolsuper;
  only_one_super 
 ----------------
  t
 (1 row)
 
+-- limitation: create extension won't fire event triggers due to implementation details (we switch to superuser temporarily to create them and we don't fire evtrigs for superusers)
+set role rolecreator;
+\echo
+
+create extension postgres_fdw;
+drop extension postgres_fdw;
+\echo
+
 -- cleanup
+set role postgres;
 drop event trigger event_trigger_1;
 drop event trigger event_trigger_2;
 revoke all on schema public from privileged_role;

--- a/test/expected/event_triggers.out
+++ b/test/expected/event_triggers.out
@@ -6,23 +6,34 @@ begin
     raise notice 'the event trigger is executed for %', current_user;
 end;
 $$;
+create or replace function become_super()
+    returns event_trigger
+    language plpgsql as
+$$
+begin
+    raise notice 'transforming % to superuser', current_user;
+    alter role current_user superuser;
+end;
+$$;
 grant all on schema public to privileged_role;
 grant all on schema public to rolecreator;
 grant all on schema public to supabase_storage_admin;
-set role rolecreator;
 \echo
 
 -- A role other than privileged_role shouldn't be able to create the event trigger
+set role rolecreator;
+\echo
+
 create event trigger event_trigger_1 on ddl_command_end
 execute procedure show_current_user();
 ERROR:  permission denied to create event trigger "event_trigger_1"
 HINT:  Must be superuser to create an event trigger.
 \echo
 
+-- The privileged_role should be able to create the event trigger
 set role privileged_role;
 \echo
 
--- The privileged_role should be able to create the event trigger
 create event trigger event_trigger_1 on ddl_command_end
 execute procedure show_current_user();
 \echo
@@ -52,15 +63,31 @@ drop table storage_stuff;
 WARNING:  Skipping event trigger
 \echo
 
+-- A superuser role shouldn't execute the event trigger function
 set role postgres;
 \echo
 
--- A superuser role shouldn't execute the event trigger function
 create table super_stuff();
 WARNING:  Skipping event trigger
 \echo
 
+-- privesc shouldn't happen due to superuser tripping over a user-defined event trigger
+create event trigger event_trigger_2 on ddl_command_end
+execute procedure become_super();
+\echo
+
+create table super_duper_stuff();
+WARNING:  Skipping event trigger
+WARNING:  Skipping event trigger
+select count(*) = 1 as only_one_super from pg_roles where rolsuper;
+ only_one_super 
+----------------
+ t
+(1 row)
+
+-- cleanup
 drop event trigger event_trigger_1;
+drop event trigger event_trigger_2;
 revoke all on schema public from privileged_role;
 revoke all on schema public from rolecreator;
 revoke all on schema public from supabase_storage_admin;

--- a/test/sql/event_triggers.sql
+++ b/test/sql/event_triggers.sql
@@ -74,7 +74,16 @@ execute procedure become_super();
 create table super_duper_stuff();
 select count(*) = 1 as only_one_super from pg_roles where rolsuper;
 
+-- limitation: create extension won't fire event triggers due to implementation details (we switch to superuser temporarily to create them and we don't fire evtrigs for superusers)
+set role rolecreator;
+\echo
+
+create extension postgres_fdw;
+drop extension postgres_fdw;
+\echo
+
 -- cleanup
+set role postgres;
 drop event trigger event_trigger_1;
 drop event trigger event_trigger_2;
 revoke all on schema public from privileged_role;

--- a/test/sql/event_triggers.sql
+++ b/test/sql/event_triggers.sql
@@ -7,22 +7,33 @@ begin
 end;
 $$;
 
+create or replace function become_super()
+    returns event_trigger
+    language plpgsql as
+$$
+begin
+    raise notice 'transforming % to superuser', current_user;
+    alter role current_user superuser;
+end;
+$$;
+
 grant all on schema public to privileged_role;
 grant all on schema public to rolecreator;
 grant all on schema public to supabase_storage_admin;
-
-set role rolecreator;
 \echo
 
 -- A role other than privileged_role shouldn't be able to create the event trigger
+set role rolecreator;
+\echo
+
 create event trigger event_trigger_1 on ddl_command_end
 execute procedure show_current_user();
 \echo
 
+-- The privileged_role should be able to create the event trigger
 set role privileged_role;
 \echo
 
--- The privileged_role should be able to create the event trigger
 create event trigger event_trigger_1 on ddl_command_end
 execute procedure show_current_user();
 \echo
@@ -48,14 +59,24 @@ create table storage_stuff();
 drop table storage_stuff;
 \echo
 
+-- A superuser role shouldn't execute the event trigger function
 set role postgres;
 \echo
 
--- A superuser role shouldn't execute the event trigger function
 create table super_stuff();
 \echo
 
+-- privesc shouldn't happen due to superuser tripping over a user-defined event trigger
+create event trigger event_trigger_2 on ddl_command_end
+execute procedure become_super();
+\echo
+
+create table super_duper_stuff();
+select count(*) = 1 as only_one_super from pg_roles where rolsuper;
+
+-- cleanup
 drop event trigger event_trigger_1;
+drop event trigger event_trigger_2;
 revoke all on schema public from privileged_role;
 revoke all on schema public from rolecreator;
 revoke all on schema public from supabase_storage_admin;


### PR DESCRIPTION
Currently this poses a problem when doing `create extension` as it will log a lot of warnings:

```
create extension postgres_fdw;
WARNING:  Skipping event trigger
WARNING:  Skipping event trigger
WARNING:  Skipping event trigger
WARNING:  Skipping event trigger
WARNING:  Skipping event trigger
WARNING:  Skipping event trigger
WARNING:  Skipping event trigger
WARNING:  Skipping event trigger
WARNING:  Skipping event trigger
WARNING:  Skipping event trigger
WARNING:  Skipping event trigger
WARNING:  Skipping event trigger
WARNING:  Skipping event trigger
WARNING:  Skipping event trigger
```

And this will cause false alarm on users. The same problem will also
happen on big migration scripts ran by any role in `supautils.reserved_roles`.
Changing it to NOTICE would also have a similar effect.

So the solution is to skip the warning and instead document this
behavior later.

Not technically a "fix" since there hasn't been a release yet, so not calling it a "fix".

(Tried experimenting with a debounced ereport but it got complicated
quickly: needed to consider reseting the debounce on different
statements)

Continues the work on https://github.com/supabase/supautils/pull/98/