### PR TITLE
Allow ALTER and DROP event trigger

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -91,6 +91,11 @@ void alter_owner(const char *obj_name, const char *role_name, altered_obj_type o
     "alter foreign data wrapper \"%s\" owner to \"%s\";\n"
     "alter role \"%s\" nosuperuser;\n";
 
+  static const char sql_evtrig_template[] =
+    "alter role \"%s\" superuser;\n"
+    "alter event trigger \"%s\" owner to \"%s\";\n"
+    "alter role \"%s\" nosuperuser;\n";
+
   static const char sql_sub_template[] =
     "alter publication \"%s\" owner to \"%s\";\n";
 
@@ -116,6 +121,15 @@ void alter_owner(const char *obj_name, const char *role_name, altered_obj_type o
              max_sql_len,
              sql_sub_template,
              obj_name,
+             role_name);
+    break;
+  case ALT_EVTRIG:
+    snprintf(sql,
+             max_sql_len,
+             sql_evtrig_template,
+             role_name,
+             obj_name,
+             role_name,
              role_name);
     break;
   }

--- a/src/utils.h
+++ b/src/utils.h
@@ -102,6 +102,7 @@ extern bool remove_ending_wildcard(char *);
 typedef enum {
   ALT_FDW
 , ALT_PUB
+, ALT_EVTRIG
 } altered_obj_type;
 
 extern void alter_owner(

--- a/test/expected/event_triggers.out.in
+++ b/test/expected/event_triggers.out.in
@@ -38,6 +38,13 @@ create event trigger event_trigger_1 on ddl_command_end
 execute procedure show_current_user();
 \echo
 
+-- the event trigger is owned by the privileged_role
+select evtowner::regrole from pg_event_trigger where evtname = 'event_trigger_1';
+    evtowner     
+-----------------
+ privileged_role
+(1 row)
+
 -- The privileged_role should execute the event trigger function
 create table privileged_stuff();
 NOTICE:  the event trigger is executed for privileged_role
@@ -72,6 +79,13 @@ create table super_stuff();
 create event trigger event_trigger_2 on ddl_command_end
 execute procedure become_super();
 \echo
+
+-- the event trigger is owned by the superuser
+select evtowner::regrole from pg_event_trigger where evtname = 'event_trigger_2';
+ evtowner 
+----------
+ postgres
+(1 row)
 
 create table super_duper_stuff();
 select count(*) = 1 as only_one_super from pg_roles where rolsuper;
@@ -110,10 +124,51 @@ create extension postgres_fdw;
 drop extension postgres_fdw;
 \echo
 
--- cleanup
+-- a non-privileged role can't alter event triggers
+set role rolecreator;
+alter event trigger event_trigger_1 disable;
+ERROR:  must be owner of event trigger event_trigger_1
+\echo
+
+-- the privileged role can alter its own event triggers
+set role privileged_role;
+alter event trigger event_trigger_1 disable;
+\echo
+
+-- but it cannot alter a superuser owned event trigger
+alter event trigger event_trigger_2 disable;
+ERROR:  must be owner of event trigger event_trigger_2
+\echo
+
+-- only the superuser can alter its own event triggers
 set role postgres;
+alter event trigger event_trigger_2 disable;
+\echo
+
+-- a non-privileged role can't drop the event triggers
+set role rolecreator;
 drop event trigger event_trigger_1;
+ERROR:  must be owner of event trigger event_trigger_1
 drop event trigger event_trigger_2;
+ERROR:  must be owner of event trigger event_trigger_2
+\echo
+
+-- the privileged role can drop its own event triggers
+set role privileged_role;
+drop event trigger event_trigger_1;
+\echo
+
+-- but it cannot drop a superuser owned event trigger
+drop event trigger event_trigger_2;
+ERROR:  must be owner of event trigger event_trigger_2
+\echo
+
+-- only the superuser can drop its own event triggers
+set role postgres;
+drop event trigger event_trigger_2;
+\echo
+
+-- cleanup
 revoke all on schema public from privileged_role;
 revoke all on schema public from rolecreator;
 revoke all on schema public from supabase_storage_admin;


### PR DESCRIPTION
Continues the work on https://github.com/supabase/supautils/pull/98, it only allowed CREATE. Now we allow ALTER and DROP:

```sql
set role privileged_role;
alter event trigger event_trigger_1 disable;
drop event trigger event_trigger_1;
```