### PR TITLE
refac: encapsulate owner change logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 GREP ?= grep
 PG_CONFIG = pg_config
 
-PG_CFLAGS = -std=c99 -Wextra -Wall -Werror -Wno-declaration-after-statement
+# the `-Wno`s quiet C90 warnings
+PG_CFLAGS = -std=c99 -Wextra -Wall -Werror \
+	-Wno-declaration-after-statement \
+	-Wno-vla \
+	-Wno-long-long
+
 ifeq ($(TEST), 1)
 	PG_CFLAGS += -DTEST
 endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -99,4 +99,15 @@ extern bool is_string_in_comma_delimited_string(const char *s1, const char *s2);
 
 extern bool remove_ending_wildcard(char *);
 
+typedef enum {
+  ALT_FDW
+, ALT_PUB
+} altered_obj_type;
+
+extern void alter_owner(
+    const char *obj_name,
+    const char *role_name,
+    altered_obj_type obj_type
+);
+
 #endif


### PR DESCRIPTION
This will avoid duplicating code for event triggers, see https://github.com/supabase/supautils/pull/106#issuecomment-2639131683.

* Adds a reusable `alter_owner` function.
* Avoids dynamic allocation and instead uses stack allocation for the generated sql.