### PR TITLE
test: make schema public create compat on pg >= 16

### DIFF
--- a/test/expected/event_triggers.out.in
+++ b/test/expected/event_triggers.out.in
@@ -15,9 +15,6 @@ begin
     alter role rolecreator superuser;
 end;
 $$;
-grant all on schema public to privileged_role;
-grant all on schema public to rolecreator;
-grant all on schema public to supabase_storage_admin;
 \echo
 
 -- A role other than privileged_role shouldn't be able to create the event trigger
@@ -166,9 +163,3 @@ ERROR:  must be owner of event trigger event_trigger_2
 -- only the superuser can drop its own event triggers
 set role postgres;
 drop event trigger event_trigger_2;
-\echo
-
--- cleanup
-revoke all on schema public from privileged_role;
-revoke all on schema public from rolecreator;
-revoke all on schema public from supabase_storage_admin;

--- a/test/expected/reserved_roles.out
+++ b/test/expected/reserved_roles.out
@@ -104,4 +104,5 @@ create role reserved_but_not_yet_created;
 alter role reserved_but_not_yet_created set search_path to 'test';
 alter role reserved_but_not_yet_created login bypassrls;
 alter role reserved_but_not_yet_created rename to renamed_reserved_role;
+drop owned by supabase_storage_admin cascade;
 drop role supabase_storage_admin;

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -34,3 +34,9 @@ grant all on schema public to nonsuper;
 grant all on schema public to nonsuper;
 grant all privileges on database postgres to nonsuper;
 \c contrib_regression
+
+-- starting from pg16 not every role can create objects on the public schema by default
+-- this makes the behavior backwards compat
+grant all on schema public to privileged_role;
+grant all on schema public to rolecreator;
+grant all on schema public to supabase_storage_admin;

--- a/test/sql/event_triggers.sql
+++ b/test/sql/event_triggers.sql
@@ -16,10 +16,6 @@ begin
     alter role rolecreator superuser;
 end;
 $$;
-
-grant all on schema public to privileged_role;
-grant all on schema public to rolecreator;
-grant all on schema public to supabase_storage_admin;
 \echo
 
 -- A role other than privileged_role shouldn't be able to create the event trigger
@@ -133,10 +129,3 @@ drop event trigger event_trigger_2;
 -- only the superuser can drop its own event triggers
 set role postgres;
 drop event trigger event_trigger_2;
-\echo
-
-
--- cleanup
-revoke all on schema public from privileged_role;
-revoke all on schema public from rolecreator;
-revoke all on schema public from supabase_storage_admin;

--- a/test/sql/reserved_roles.sql
+++ b/test/sql/reserved_roles.sql
@@ -82,4 +82,5 @@ create role reserved_but_not_yet_created;
 alter role reserved_but_not_yet_created set search_path to 'test';
 alter role reserved_but_not_yet_created login bypassrls;
 alter role reserved_but_not_yet_created rename to renamed_reserved_role;
+drop owned by supabase_storage_admin cascade;
 drop role supabase_storage_admin;


### PR DESCRIPTION
Starting from pg16 not every role can create objects on the public schema by default, this is troublesome for tests that need to create objects using any role since in each test file we need to `grant` explicit privileges.

Instead we make grant these privileges globally on `test/fixtures.sql`:
```sql
grant all on schema public to privileged_role;
grant all on schema public to rolecreator;
grant all on schema public to supabase_storage_admin;
```