### PR TITLE
feat: execute event triggers under superuser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ PG_CFLAGS += --coverage
 endif
 
 MODULE_big = supautils
-OBJS = src/supautils.o src/privileged_extensions.o src/drop_trigger_grants.o src/constrained_extensions.o src/extensions_parameter_overrides.o src/policy_grants.o src/utils.o
+SRC = $(wildcard src/*.c)
+OBJS = $(patsubst src/%.c, src/%.o, $(SRC))
 
 PG_VERSION = $(strip $(shell $(PG_CONFIG) --version | $(GREP) -oP '(?<=PostgreSQL )[0-9]+'))
 PG_GE16 = $(shell test $(PG_VERSION) -ge 16; echo $$?)

--- a/src/event_triggers.c
+++ b/src/event_triggers.c
@@ -1,0 +1,46 @@
+#include "pg_prelude.h"
+#include "event_triggers.h"
+
+PG_FUNCTION_INFO_V1(noop);
+Datum noop(__attribute__ ((unused)) PG_FUNCTION_ARGS) { PG_RETURN_VOID();}
+
+void
+force_noop(FmgrInfo *finfo)
+{
+    finfo->fn_addr   = (PGFunction) noop;
+    finfo->fn_oid    = InvalidOid;           /* not a known function OID anymore */
+    finfo->fn_nargs  = 0;                    /* no arguments for noop */
+    finfo->fn_strict = false;
+    finfo->fn_retset = false;
+    finfo->fn_stats  = 0;                    /* no stats collection */
+    finfo->fn_extra  = NULL;                 /* clear out old context data */
+    finfo->fn_mcxt   = CurrentMemoryContext;
+    finfo->fn_expr   = NULL;                 /* no parse tree */
+}
+
+Oid get_function_owner(func_owner_search search){
+  // Lookup function name OID. Note that for event trigger functions, there's no arguments.
+  Oid func_oid = InvalidOid;
+
+  switch(search.as){
+  case FO_SEARCH_NAME:
+    func_oid = LookupFuncName(search.val.funcname, 0, NULL, false);
+    break;
+  case FO_SEARCH_FINFO:
+    func_oid = search.val.finfo->fn_oid;
+    break;
+  }
+
+  HeapTuple proc_tup = SearchSysCache1(PROCOID, ObjectIdGetDatum(func_oid));
+  if (!HeapTupleIsValid(proc_tup))
+      ereport(ERROR,
+              (errmsg("cache lookup failed for function %u", func_oid)));
+
+  Form_pg_proc procForm = (Form_pg_proc) GETSTRUCT(proc_tup);
+  Oid func_owner = procForm->proowner;
+
+  ReleaseSysCache(proc_tup);
+
+  return func_owner;
+}
+

--- a/src/event_triggers.h
+++ b/src/event_triggers.h
@@ -1,0 +1,21 @@
+#ifndef EVENT_TRIGGERS_H
+#define EVENT_TRIGGERS_H
+
+typedef enum {
+  FO_SEARCH_NAME,
+  FO_SEARCH_FINFO
+} func_owner_search_type;
+
+typedef struct {
+    func_owner_search_type as;
+    union {
+        List     *funcname;
+        FmgrInfo *finfo;
+    } val;
+} func_owner_search;
+
+extern Oid get_function_owner(func_owner_search search);
+
+extern void force_noop(FmgrInfo *finfo);
+
+#endif

--- a/src/pg_prelude.h
+++ b/src/pg_prelude.h
@@ -8,12 +8,14 @@
 #include <common/jsonapi.h>
 #include <catalog/namespace.h>
 #include <catalog/pg_authid.h>
+#include <catalog/pg_proc.h>
 #include <commands/defrem.h>
 #include <executor/spi.h>
 #include <fmgr.h>
 #include <miscadmin.h>
 #include <nodes/makefuncs.h>
 #include <nodes/pg_list.h>
+#include <parser/parse_func.h>
 #include <tcop/utility.h>
 #include <tsearch/ts_locale.h>
 #include <utils/acl.h>
@@ -24,6 +26,7 @@
 #include <utils/json.h>
 #include <utils/jsonb.h>
 #include <utils/jsonfuncs.h>
+#include <utils/syscache.h>
 #include <utils/lsyscache.h>
 #include <utils/memutils.h>
 #include <utils/regproc.h>

--- a/test/expected/event_triggers.out.in
+++ b/test/expected/event_triggers.out.in
@@ -1,4 +1,8 @@
-create or replace function show_current_user()
+-- create a function owned by a non-superuser
+set role privileged_role;
+\echo
+
+create function show_current_user()
     returns event_trigger
     language plpgsql as
 $$
@@ -6,18 +10,9 @@ begin
     raise notice 'the event trigger is executed for %', current_user;
 end;
 $$;
-create or replace function become_super()
-    returns event_trigger
-    language plpgsql as
-$$
-begin
-    raise notice 'transforming % to superuser', current_user;
-    alter role rolecreator superuser;
-end;
-$$;
 \echo
 
--- A role other than privileged_role shouldn't be able to create the event trigger
+-- A role other than privileged_role shouldn't be able to create an event trigger
 set role rolecreator;
 \echo
 
@@ -47,18 +42,28 @@ create table privileged_stuff();
 NOTICE:  the event trigger is executed for privileged_role
 \echo
 
-set role rolecreator;
+-- A superuser is not able to create event trigger using non-superuser function
+set role postgres;
+\echo
+
+create event trigger event_trigger_2 on ddl_command_end
+execute procedure show_current_user();
+ERROR:  Superuser owned event trigger must execute a superuser owned function
+DETAIL:  The current user "postgres" is a superuser and the function "show_current_user" is owned by a non-superuser
 \echo
 
 -- A role other than privileged_role should execute the event trigger function
+set role rolecreator;
+\echo
+
 create function dummy() returns text as $$ select 'dummy'; $$ language sql;
 NOTICE:  the event trigger is executed for rolecreator
 \echo
 
+-- A reserved_role shouldn't execute the event trigger function
 set role supabase_storage_admin;
 \echo
 
--- A reserved_role shouldn't execute the event trigger function
 create table storage_stuff();
 \echo
 
@@ -72,17 +77,37 @@ set role postgres;
 create table super_stuff();
 \echo
 
+-- extensions won't execute the event trigger function (since they're executed by superuser under our implementation)
+set role rolecreator;
+\echo
+
+create extension postgres_fdw;
+drop extension postgres_fdw;
+\echo
+
 -- privesc shouldn't happen due to superuser tripping over a user-defined event trigger
+set role privileged_role;
+\echo
+
+create or replace function become_super()
+    returns event_trigger
+    language plpgsql as
+$$
+begin
+    raise notice 'transforming % to superuser', current_user;
+    alter role rolecreator superuser;
+end;
+$$;
+NOTICE:  the event trigger is executed for privileged_role
+\echo
+
 create event trigger event_trigger_2 on ddl_command_end
 execute procedure become_super();
 \echo
 
--- the event trigger is owned by the superuser
-select evtowner::regrole from pg_event_trigger where evtname = 'event_trigger_2';
- evtowner 
-----------
- postgres
-(1 row)
+-- when switching to super, the become_super evtrig won't fire
+set role postgres;
+\echo
 
 create table super_duper_stuff();
 select count(*) = 1 as only_one_super from pg_roles where rolsuper;
@@ -113,14 +138,6 @@ CONTEXT:  SQL statement "alter role rolecreator superuser"
 PL/pgSQL function become_super() line 4 at SQL statement
 \echo
 
--- limitation: create extension won't fire event triggers due to implementation details (we switch to superuser temporarily to create them and we don't fire evtrigs for superusers)
-set role rolecreator;
-\echo
-
-create extension postgres_fdw;
-drop extension postgres_fdw;
-\echo
-
 -- a non-privileged role can't alter event triggers
 set role rolecreator;
 alter event trigger event_trigger_1 disable;
@@ -132,34 +149,13 @@ set role privileged_role;
 alter event trigger event_trigger_1 disable;
 \echo
 
--- but it cannot alter a superuser owned event trigger
-alter event trigger event_trigger_2 disable;
-ERROR:  must be owner of event trigger event_trigger_2
-\echo
-
--- only the superuser can alter its own event triggers
-set role postgres;
-alter event trigger event_trigger_2 disable;
-\echo
-
 -- a non-privileged role can't drop the event triggers
 set role rolecreator;
 drop event trigger event_trigger_1;
 ERROR:  must be owner of event trigger event_trigger_1
-drop event trigger event_trigger_2;
-ERROR:  must be owner of event trigger event_trigger_2
 \echo
 
 -- the privileged role can drop its own event triggers
 set role privileged_role;
 drop event trigger event_trigger_1;
-\echo
-
--- but it cannot drop a superuser owned event trigger
-drop event trigger event_trigger_2;
-ERROR:  must be owner of event trigger event_trigger_2
-\echo
-
--- only the superuser can drop its own event triggers
-set role postgres;
 drop event trigger event_trigger_2;

--- a/test/expected/event_triggers_super.out
+++ b/test/expected/event_triggers_super.out
@@ -1,0 +1,118 @@
+-- a superuser can create an event trigger
+set role postgres;
+\echo
+
+create function super_show_current_user()
+    returns event_trigger
+    language plpgsql as
+$$
+begin
+    raise notice 'superuser mandated event trigger: current_user is %', current_user;
+end;
+$$;
+\echo
+
+create event trigger event_trigger_1 on ddl_command_end
+execute procedure super_show_current_user();
+\echo
+
+-- the event trigger is owned by the superuser
+select evtowner::regrole from pg_event_trigger where evtname = 'event_trigger_1';
+ evtowner 
+----------
+ postgres
+(1 row)
+
+-- the superuser evtrig will execute for superuser
+create table super_thing();
+NOTICE:  superuser mandated event trigger: current_user is postgres
+\echo
+
+-- A regular user is not able to create event trigger using a superuser function
+set role privileged_role;
+\echo
+
+create event trigger event_trigger_2 on ddl_command_end
+execute procedure super_show_current_user();
+ERROR:  Non-superuser owned event trigger must execute a non-superuser owned function
+DETAIL:  The current user "privileged_role" is not a superuser and the function "super_show_current_user" is owned by a superuser
+\echo
+
+-- A reserved role will execute the superuser evtrig
+set role supabase_storage_admin;
+\echo
+
+create table storage_stuff();
+NOTICE:  superuser mandated event trigger: current_user is supabase_storage_admin
+\echo
+
+drop table storage_stuff;
+NOTICE:  superuser mandated event trigger: current_user is supabase_storage_admin
+\echo
+
+-- creating extensions will fire superuser evtrigs
+set role privileged_role;
+\echo
+
+create extension postgres_fdw;
+NOTICE:  superuser mandated event trigger: current_user is postgres
+drop extension postgres_fdw;
+NOTICE:  superuser mandated event trigger: current_user is postgres
+\echo
+
+-- a non-privileged role cannot alter a superuser owned evtrig
+set role rolecreator;
+\echo
+
+alter event trigger event_trigger_1 disable;
+ERROR:  must be owner of event trigger event_trigger_1
+\echo
+
+-- the privileged role cannot alter a superuser owned evtrig
+set role privileged_role;
+\echo
+
+alter event trigger event_trigger_1 disable;
+ERROR:  must be owner of event trigger event_trigger_1
+\echo
+
+-- a reserved role cannot alter a superuser owned evtrig
+set role supabase_storage_admin;
+\echo
+
+alter event trigger event_trigger_1 disable;
+ERROR:  must be owner of event trigger event_trigger_1
+\echo
+
+-- only the superuser can alter its own event triggers
+set role postgres;
+alter event trigger event_trigger_1 disable;
+\echo
+
+-- a non-privileged role cannot drop a superuser owned evtrig
+set role rolecreator;
+\echo
+
+drop event trigger event_trigger_1;
+ERROR:  must be owner of event trigger event_trigger_1
+\echo
+
+-- the privileged role cannot drop a superuser owned evtrig
+set role privileged_role;
+\echo
+
+drop event trigger event_trigger_1;
+ERROR:  must be owner of event trigger event_trigger_1
+\echo
+
+-- a reserved role cannot drop a superuser owned evtrig
+set role supabase_storage_admin;
+\echo
+
+drop event trigger event_trigger_1;
+ERROR:  must be owner of event trigger event_trigger_1
+\echo
+
+-- only the superuser can drop its own event triggers
+set role postgres;
+drop event trigger event_trigger_1;

--- a/test/sql/event_triggers.sql
+++ b/test/sql/event_triggers.sql
@@ -1,4 +1,8 @@
-create or replace function show_current_user()
+-- create a function owned by a non-superuser
+set role privileged_role;
+\echo
+
+create function show_current_user()
     returns event_trigger
     language plpgsql as
 $$
@@ -6,19 +10,9 @@ begin
     raise notice 'the event trigger is executed for %', current_user;
 end;
 $$;
-
-create or replace function become_super()
-    returns event_trigger
-    language plpgsql as
-$$
-begin
-    raise notice 'transforming % to superuser', current_user;
-    alter role rolecreator superuser;
-end;
-$$;
 \echo
 
--- A role other than privileged_role shouldn't be able to create the event trigger
+-- A role other than privileged_role shouldn't be able to create an event trigger
 set role rolecreator;
 \echo
 
@@ -41,17 +35,25 @@ select evtowner::regrole from pg_event_trigger where evtname = 'event_trigger_1'
 create table privileged_stuff();
 \echo
 
-set role rolecreator;
+-- A superuser is not able to create event trigger using non-superuser function
+set role postgres;
+\echo
+
+create event trigger event_trigger_2 on ddl_command_end
+execute procedure show_current_user();
 \echo
 
 -- A role other than privileged_role should execute the event trigger function
+set role rolecreator;
+\echo
+
 create function dummy() returns text as $$ select 'dummy'; $$ language sql;
 \echo
 
+-- A reserved_role shouldn't execute the event trigger function
 set role supabase_storage_admin;
 \echo
 
--- A reserved_role shouldn't execute the event trigger function
 create table storage_stuff();
 \echo
 
@@ -65,13 +67,36 @@ set role postgres;
 create table super_stuff();
 \echo
 
+-- extensions won't execute the event trigger function (since they're executed by superuser under our implementation)
+set role rolecreator;
+\echo
+
+create extension postgres_fdw;
+drop extension postgres_fdw;
+\echo
+
 -- privesc shouldn't happen due to superuser tripping over a user-defined event trigger
+set role privileged_role;
+\echo
+
+create or replace function become_super()
+    returns event_trigger
+    language plpgsql as
+$$
+begin
+    raise notice 'transforming % to superuser', current_user;
+    alter role rolecreator superuser;
+end;
+$$;
+\echo
+
 create event trigger event_trigger_2 on ddl_command_end
 execute procedure become_super();
 \echo
 
--- the event trigger is owned by the superuser
-select evtowner::regrole from pg_event_trigger where evtname = 'event_trigger_2';
+-- when switching to super, the become_super evtrig won't fire
+set role postgres;
+\echo
 
 create table super_duper_stuff();
 select count(*) = 1 as only_one_super from pg_roles where rolsuper;
@@ -84,14 +109,6 @@ set role rolecreator;
 create table dummy();
 \echo
 
--- limitation: create extension won't fire event triggers due to implementation details (we switch to superuser temporarily to create them and we don't fire evtrigs for superusers)
-set role rolecreator;
-\echo
-
-create extension postgres_fdw;
-drop extension postgres_fdw;
-\echo
-
 -- a non-privileged role can't alter event triggers
 set role rolecreator;
 alter event trigger event_trigger_1 disable;
@@ -102,30 +119,12 @@ set role privileged_role;
 alter event trigger event_trigger_1 disable;
 \echo
 
--- but it cannot alter a superuser owned event trigger
-alter event trigger event_trigger_2 disable;
-\echo
-
--- only the superuser can alter its own event triggers
-set role postgres;
-alter event trigger event_trigger_2 disable;
-\echo
-
 -- a non-privileged role can't drop the event triggers
 set role rolecreator;
 drop event trigger event_trigger_1;
-drop event trigger event_trigger_2;
 \echo
 
 -- the privileged role can drop its own event triggers
 set role privileged_role;
 drop event trigger event_trigger_1;
-\echo
-
--- but it cannot drop a superuser owned event trigger
-drop event trigger event_trigger_2;
-\echo
-
--- only the superuser can drop its own event triggers
-set role postgres;
 drop event trigger event_trigger_2;

--- a/test/sql/event_triggers_super.sql
+++ b/test/sql/event_triggers_super.sql
@@ -1,0 +1,101 @@
+-- a superuser can create an event trigger
+set role postgres;
+\echo
+
+create function super_show_current_user()
+    returns event_trigger
+    language plpgsql as
+$$
+begin
+    raise notice 'superuser mandated event trigger: current_user is %', current_user;
+end;
+$$;
+\echo
+
+create event trigger event_trigger_1 on ddl_command_end
+execute procedure super_show_current_user();
+\echo
+
+-- the event trigger is owned by the superuser
+select evtowner::regrole from pg_event_trigger where evtname = 'event_trigger_1';
+
+-- the superuser evtrig will execute for superuser
+create table super_thing();
+\echo
+
+-- A regular user is not able to create event trigger using a superuser function
+set role privileged_role;
+\echo
+
+create event trigger event_trigger_2 on ddl_command_end
+execute procedure super_show_current_user();
+\echo
+
+-- A reserved role will execute the superuser evtrig
+set role supabase_storage_admin;
+\echo
+
+create table storage_stuff();
+\echo
+
+drop table storage_stuff;
+\echo
+
+-- creating extensions will fire superuser evtrigs
+set role privileged_role;
+\echo
+
+create extension postgres_fdw;
+drop extension postgres_fdw;
+\echo
+
+-- a non-privileged role cannot alter a superuser owned evtrig
+set role rolecreator;
+\echo
+
+alter event trigger event_trigger_1 disable;
+\echo
+
+-- the privileged role cannot alter a superuser owned evtrig
+set role privileged_role;
+\echo
+
+alter event trigger event_trigger_1 disable;
+\echo
+
+-- a reserved role cannot alter a superuser owned evtrig
+set role supabase_storage_admin;
+\echo
+
+alter event trigger event_trigger_1 disable;
+\echo
+
+-- only the superuser can alter its own event triggers
+set role postgres;
+alter event trigger event_trigger_1 disable;
+\echo
+
+-- a non-privileged role cannot drop a superuser owned evtrig
+set role rolecreator;
+\echo
+
+drop event trigger event_trigger_1;
+\echo
+
+-- the privileged role cannot drop a superuser owned evtrig
+set role privileged_role;
+\echo
+
+drop event trigger event_trigger_1;
+\echo
+
+-- a reserved role cannot drop a superuser owned evtrig
+set role supabase_storage_admin;
+\echo
+
+drop event trigger event_trigger_1;
+\echo
+
+-- only the superuser can drop its own event triggers
+set role postgres;
+drop event trigger event_trigger_1;


### PR DESCRIPTION
Closes https://github.com/supabase/supautils/issues/110.

superuser evtrigs now work as usual with the exception of `CREATE EXTENSION`. Which will now fire superuser evtrigs, but not regular user evtrigs.

This is because how `CREATE EXTENSION` works under supautils (switchs to superuser before executing CREATE EXTENSION).