### PR TITLE
Document privileged role

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/supabase/supautils/badge.svg?branch=master)](https://coveralls.io/github/supabase/supautils?branch=master)
 
-Supautils is an extension that secures a PostgreSQL cluster on a cloud environment.
+Supautils is an extension that secures a PostgreSQL cluster on a cloud environment. It's controlled through settings, it doesn't require database tables or functions.
 
-It doesn't require creating database objects. It's a shared library that modifies PostgreSQL behavior through "hooks", not through tables or functions.
-
-It's tested to work on PostgreSQL 13, 14, 15, 16 and 17.
+Tested to work on PostgreSQL 13, 14, 15, 16 and 17.
 
 ## Installation
 
@@ -16,22 +14,27 @@ Clone this repo and run
 make && make install
 ```
 
-To make it available on some PostgreSQL roles
+To make supautils available to the whole cluster, you can add the following to `postgresql.conf` (use `SHOW config_file` for finding the location).
 
 ```
-ALTER ROLE role1 SET session_preload_libraries TO 'supautils';
-ALTER ROLE role2 SET session_preload_libraries TO 'supautils';
-```
-
-Or to make it available to the whole cluster
-
-```
-# add the following on postgresql.conf
-# use SHOW config_file; for finding the location
 shared_preload_libraries = 'supautils'
 ```
 
-## Role Security
+Or to make it available only on some PostgreSQL roles use `session_preload_libraries`.
+
+```
+ALTER ROLE role1 SET session_preload_libraries TO 'supautils';
+```
+
+## Features
+
+- [Reserved Roles](#reserved-roles)
+- [Privileged extensions](#privileged-extensions)
+- [Constrained extensions](#constrained-extensions)
+- [Extensions Parameter Overrides](#extensions-parameter-overrides)
+- [Table Ownership Bypass](#table-ownership-bypass)
+
+### Reserved Roles
 
 This functionality prevents non-superusers from modifying/granting a set of roles.
 
@@ -64,7 +67,7 @@ For example, you can restrict doing `GRANT pg_read_server_files TO my_role` with
 supautils.reserved_memberships = 'pg_read_server_files'
 ```
 
-### Configuration
+#### Configuration
 
 Settings available:
 
@@ -73,7 +76,7 @@ supautils.reserved_roles = 'supabase_admin,supabase_auth_admin,supabase_storage_
 supautils.reserved_memberships = 'pg_read_server_files, pg_write_server_files, pg_execute_server_program'
 ```
 
-## Privileged Extensions
+### Privileged Extensions
 
 This functionality is adapted from [pgextwlist](https://github.com/dimitri/pgextwlist).
 
@@ -111,7 +114,7 @@ grant all on type hstore to non_superuser_role;
 
 This is useful for things like creating a dedicated role per extension and granting privileges as needed to that role.
 
-### Configuration
+#### Configuration
 
 Settings available:
 
@@ -121,7 +124,7 @@ supautils.privileged_extensions_custom_scripts_path = '/opt/postgresql/privilege
 supautils.privileged_extensions_superuser = 'postgres'
 ```
 
-## Constrained Extensions
+### Constrained Extensions
 
 You can constrain the resources needed for an extension to be installed. This is done through:
 
@@ -150,7 +153,7 @@ DETAIL:  required CPUs: 16
 HINT:  upgrade to an instance with higher resources
 ```
 
-## Extensions Parameter Overrides
+### Extensions Parameter Overrides
 
 You can override `CREATE EXTENSION` parameters like so:
 
@@ -173,7 +176,9 @@ postgres=> \dx pg_cron
 (1 row)
 ```
 
-## Managing Policies Without Table Ownership
+### Table Ownership Bypass
+
+#### Manage Policies
 
 In Postgres, only table owners can create RLS policies for a table. This can be
 limiting if you need to allow certain roles to manage policies without allowing
@@ -188,10 +193,9 @@ supautils.policy_grants = '{ "my_role": ["public.not_my_table", "public.also_not
 This allows `my_role` to manage policies for `public.not_my_table` and
 `public.also_not_my_table` without being an owner of these tables.
 
-## Dropping Triggers Without Table Ownership
+#### Drop Triggers
 
-In addition to managing policies, you can also allow certain roles to drop
-triggers on a table without being the table owner:
+You can also allow certain roles to drop triggers on a table without being the table owner:
 
 ```
 supautils.drop_trigger_grants = '{ "my_role": ["public.not_my_table", "public.also_not_my_table"] }'

--- a/README.md
+++ b/README.md
@@ -195,6 +195,26 @@ When the privileged role executes `create publication`, supautils will detect th
 
 An analogous mechanism is done for doing `create foreign data wrapper` without superuser.
 
+#### Privileged Settings
+
+Certain settings like `session_replication_role` can only be set by superusers. The privileged role can be allowed to change these settings by listing them in:
+
+```
+privileged_role_allowed_configs="session_replication_role"
+```
+
+Some extensions also have their own superuser settings with a prefix, those can be configured by:
+
+```
+privileged_role_allowed_configs="ext.setting, other.nested"
+```
+
+You can also choose to allow all the extension settings by using a wildcard:
+
+```
+privileged_role_allowed_configs="ext.*"
+```
+
 ### Table Ownership Bypass
 
 #### Manage Policies

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ ALTER ROLE role1 SET session_preload_libraries TO 'supautils';
 - [Reserved Roles](#reserved-roles)
 - [Privileged extensions](#privileged-extensions)
 - [Constrained extensions](#constrained-extensions)
-- [Privileged role](#privileged-role)
 - [Extensions Parameter Overrides](#extensions-parameter-overrides)
+- [Privileged Role](#privileged-role)
 - [Table Ownership Bypass](#table-ownership-bypass)
 
 ### Reserved Roles
@@ -171,6 +171,19 @@ postgres=> \dx pg_cron
  pg_cron | 1.5     | pg_catalog | Job scheduler for PostgreSQL
 (1 row)
 ```
+
+### Privileged Role
+
+PostgreSQL doesn't allow non-superusers to create certain database objects like publications or foreign data wrappers. supautils allows creating these by configuring a `supautils.privileged_role`.
+This role is a proxy role for a SUPERUSER (configured by `supautils.superuser`).
+
+When the privileged role executes `create publication`, supautils will detect the statement and:
+
+- It will switch to the `supautils.superuser`, allowing the operation and creating the publication.
+- It will change the ownership of the publication to the privileged role.
+- Finally, it will switch back to the privileged role.
+
+An analogous mechanism is done for doing `create foreign data wrapper` without superuser.
 
 ### Table Ownership Bypass
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ For example, you can restrict doing `GRANT pg_read_server_files TO my_role` by s
 supautils.reserved_memberships = 'pg_read_server_files'
 ```
 
+#### Reserved Roles Settings
+
+By default, reserved roles cannot have their settings changed. However their settings can be modified by the [Privileged Role](#privileged-role) if they're configured like so:
+
+```
+supautils.reserved_roles = 'connector*, storage_admin*'
+```
+
+That is, the role must end with a `*` suffix.
+
 ### Privileged Extensions
 
 This functionality is adapted from [pgextwlist](https://github.com/dimitri/pgextwlist).


### PR DESCRIPTION
Closes https://github.com/supabase/supautils/issues/116.

[Rendered](https://github.com/steve-chavez/supautils/blob/fix-docs/README.md)

Note that documenting the privileged role is required for documenting  event triggers https://github.com/supabase/supautils/pull/115

Also reorganizes the docs and renames some features for easier understanding.