### PR TITLE
ci: fix copying .so file on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           # Copy files into directory structure
           mkdir -p ${package_dir}/usr/lib/postgresql/lib
           mkdir -p ${package_dir}/var/lib/postgresql/extension
-          cp *.so ${package_dir}/usr/lib/postgresql/lib
+          cp build/*.so ${package_dir}/usr/lib/postgresql/lib
 
           # symlinks to Copy files into directory structure
           mkdir -p ${package_dir}/usr/lib/postgresql/${{ matrix.postgres }}/lib


### PR DESCRIPTION
ci is failing https://github.com/supabase/supautils/actions/runs/14175457332/job/39709154581#step:3:154