### PR TITLE
fix: evtrigs use existing version function as noop

### DIFF
--- a/src/event_triggers.c
+++ b/src/event_triggers.c
@@ -1,15 +1,15 @@
 #include "pg_prelude.h"
 #include "event_triggers.h"
 
-PG_FUNCTION_INFO_V1(noop);
-Datum noop(__attribute__ ((unused)) PG_FUNCTION_ARGS) { PG_RETURN_VOID();}
+// this is the underlying function of `select version();`
+extern Datum pgsql_version(PG_FUNCTION_ARGS);
 
 void
 force_noop(FmgrInfo *finfo)
 {
-    finfo->fn_addr   = (PGFunction) noop;
-    finfo->fn_oid    = 38;                   /* put the int2in oid which is sure to exist, this avoids cache lookup errors. See https://github.com/supabase/supautils/pull/129*/
-    finfo->fn_nargs  = 0;                    /* no arguments for noop */
+    finfo->fn_addr   = (PGFunction) pgsql_version;
+    finfo->fn_oid    = 89;                   /* this is the oid of pgsql_version function, it's stable and keeps being the same on latest pg version */
+    finfo->fn_nargs  = 0;                    /* no arguments for version() */
     finfo->fn_strict = false;
     finfo->fn_retset = false;
     finfo->fn_stats  = 0;                    /* no stats collection */

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -101,10 +101,11 @@ static void supautils_fmgr_hook(FmgrHookEventType event, FmgrInfo *flinfo, Datum
         const char *current_role_name = GetUserNameFromId(GetUserId(), false);
         if (superuser() || is_reserved_role(current_role_name, false)) {
             bool function_is_owned_by_super = superuser_arg(get_function_owner((func_owner_search){ .as = FO_SEARCH_FINFO, .val.finfo = flinfo }));
-            if (!function_is_owned_by_super)
-            // we can't skip execution directly inside the fmgr_hook (although we can abort it with ereport)
-            // so instead we use the workaround of changing the event trigger function to a noop function
-            force_noop(flinfo);
+            if (!function_is_owned_by_super){
+                // we can't skip execution directly inside the fmgr_hook (although we can abort it with ereport)
+                // so instead we use the workaround of changing the event trigger function to a noop function
+                force_noop(flinfo);
+            }
         }
 
         if (next_fmgr_hook)


### PR DESCRIPTION
Previous [fix](https://github.com/supabase/supautils/pull/129) could override an existing function.