### PR TITLE
feat: log skipped event triggers when enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ To protect against privilege escalation, the event triggers created by the privi
 - Will be skipped for any superuser role.
 - For PostgreSQL < 16: Will also be skipped for [Reserved Roles](#reserved-roles).
 
+The skipping behavior can be logged by setting the `supautils.log_skipped_evtrigs` config to true, this is false by default.
+
 Superuser event triggers work as usual, with the additional restriction that the event trigger function must be owned by a superuser.
 
 ```sql

--- a/test/expected/event_triggers.out.in
+++ b/test/expected/event_triggers.out.in
@@ -116,6 +116,16 @@ select count(*) = 1 as only_one_super from pg_roles where rolsuper;
  t
 (1 row)
 
+-- ensure logging skipped event triggers happens when enabled
+set supautils.log_skipped_evtrigs = true;
+\echo
+
+create table supa_stuff();
+NOTICE:  Skipping event trigger function "show_current_user" for user "postgres"
+NOTICE:  Skipping event trigger function "become_super" for user "postgres"
+reset supautils.log_skipped_evtrigs;
+\echo
+
 -- privesc won't happen because the event trigger function will fire with the privileges
 -- of the current role (this is pg default behavior)
 set role rolecreator;

--- a/test/sql/event_triggers.sql
+++ b/test/sql/event_triggers.sql
@@ -101,6 +101,15 @@ set role postgres;
 create table super_duper_stuff();
 select count(*) = 1 as only_one_super from pg_roles where rolsuper;
 
+-- ensure logging skipped event triggers happens when enabled
+set supautils.log_skipped_evtrigs = true;
+\echo
+
+create table supa_stuff();
+
+reset supautils.log_skipped_evtrigs;
+\echo
+
 -- privesc won't happen because the event trigger function will fire with the privileges
 -- of the current role (this is pg default behavior)
 set role rolecreator;


### PR DESCRIPTION
Adds a boolean `supautils.log_skipped_evtrigs` GUC, false by default.

This will log skipped evtrigs with a NOTICE level like:

```sql
set role postgres;
set supautils.log_skipped_evtrigs = true;

create table supa_stuff();
NOTICE:  Skipping event trigger function "show_current_user" for user "postgres"
NOTICE:  Skipping event trigger function "become_super" for user "postgres"
```
