### PR TITLE
feat: no non-immutable funcs in check constraints

### DIFF
--- a/src/immutable_check.c
+++ b/src/immutable_check.c
@@ -1,0 +1,80 @@
+#include "pg_prelude.h"
+#include "immutable_check.h"
+
+static const char invalid_functions[][NAMEDATALEN] = {
+    "now",
+    "current_setting"
+};
+static const size_t num_invalid_funcs = sizeof(invalid_functions) / NAMEDATALEN;
+
+static bool
+contains_invalid_function_walker(Node *node, void *context)
+{
+    if (node == NULL)
+        return false;
+
+    if (IsA(node, FuncCall))
+    {
+        FuncCall *fcall = (FuncCall *) node;
+        /*
+         * fcall->funcname is a list of identifiers. If not schema-qualified,
+         * it's just one element (the function name).
+         * TODO: consider schema qualifications
+         */
+        if (fcall->funcname != NIL)
+        {
+            ListCell *fname = llast(fcall->funcname);
+            if (fname && IsA(fname, String))
+            {
+                for(size_t i = 0; i < num_invalid_funcs; i++){
+                    if (pg_strcasecmp(strVal(fname), invalid_functions[i]) == 0)
+                        return true;
+                }
+            }
+        }
+    }
+
+    // continue recursing into subnodes
+    return raw_expression_tree_walker(node, contains_invalid_function_walker, context);
+}
+
+static bool
+contains_invalid_function(Node *node, __attribute__((unused)) void *context)
+{
+    return raw_expression_tree_walker(node, contains_invalid_function_walker, NULL);
+}
+
+bool contains_non_immutable_check_constraints(CreateStmt *stmt){
+    ListCell   *lc;
+    /*
+     *Look for tableElts which can contain ColumnDefs and TableConstraints
+     *TODO: also consider TableConstraints
+     */
+    foreach(lc, stmt->tableElts)
+    {
+      Node *elt = (Node *) lfirst(lc);
+
+      if (elt == NULL)
+          continue;
+
+      // If it's a ColumnDef, check `constraints` field.
+      if (IsA(elt, ColumnDef))
+      {
+          ColumnDef  *cdef = (ColumnDef *) elt;
+          ListCell   *constraint_lc;
+
+          foreach(constraint_lc, cdef->constraints)
+          {
+              Constraint *constr = (Constraint *) lfirst(constraint_lc);
+              if (constr->contype == CONSTR_CHECK && constr->raw_expr)
+              {
+                  if (contains_invalid_function((Node *) constr->raw_expr, NULL))
+                      return true;
+              }
+          }
+      }
+    }
+
+    return false;
+}
+

--- a/src/immutable_check.h
+++ b/src/immutable_check.h
@@ -1,0 +1,3 @@
+#include "pg_prelude.h"
+
+bool contains_non_immutable_check_constraints(CreateStmt *stmt);

--- a/src/pg_prelude.h
+++ b/src/pg_prelude.h
@@ -14,6 +14,7 @@
 #include <fmgr.h>
 #include <miscadmin.h>
 #include <nodes/makefuncs.h>
+#include <nodes/nodeFuncs.h>
 #include <nodes/pg_list.h>
 #include <parser/parse_func.h>
 #include <tcop/utility.h>

--- a/test/expected/immutable_check.out
+++ b/test/expected/immutable_check.out
@@ -1,0 +1,12 @@
+create table products (
+    product_no integer,
+    date timestamptz check (now() > '2025-03-01')
+);
+ERROR:  usage of non-immutable function in CHECK constraints are forbidden
+\echo
+
+create table products (
+    product_no integer,
+    name text check (name <> current_setting('request.name', true))
+);
+ERROR:  usage of non-immutable function in CHECK constraints are forbidden

--- a/test/sql/immutable_check.sql
+++ b/test/sql/immutable_check.sql
@@ -1,0 +1,10 @@
+create table products (
+    product_no integer,
+    date timestamptz check (now() > '2025-03-01')
+);
+\echo
+
+create table products (
+    product_no integer,
+    name text check (name <> current_setting('request.name', true))
+);


### PR DESCRIPTION
## Problem

A common failure mode of restores or other similar workflows is for a database to contain check constraints that are not immutable. This is not supported by Postgres, but not flagged when such a constraint is created: https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-CHECK-CONSTRAINTS

## Solution

Forbid the use non-immutable functions on check constraint at CREATE or ALTER time.

Implementation:

- [x] POC: right now it only works for `now` and `current_setting`
- [ ] table level check constraint
- [ ] alter table statements
- [ ] expand on invalid functions instead of having an static array