### PR TITLE
refactor: rm run_process_utility_hook from internal module

### DIFF
--- a/src/privileged_extensions.h
+++ b/src/privileged_extensions.h
@@ -11,16 +11,8 @@ extern void handle_create_extension(
     const char *privileged_extensions_custom_scripts_path,
     const extension_parameter_overrides *epos, const size_t total_epos);
 
-extern void
-handle_alter_extension(void (*process_utility_hook)(PROCESS_UTILITY_PARAMS),
-                       PROCESS_UTILITY_PARAMS,
-                       const char *extname,
-                       const char *privileged_extensions,
-                       const char *superuser);
+bool all_extensions_are_privileged(List *objects, const char *privileged_extensions);
 
-extern void
-handle_drop_extension(void (*process_utility_hook)(PROCESS_UTILITY_PARAMS),
-                      PROCESS_UTILITY_PARAMS, const char *privileged_extensions,
-                      const char *superuser);
+bool is_extension_privileged(const char *extname, const char *privileged_extensions);
 
 #endif


### PR DESCRIPTION
Partly addresses https://github.com/supabase/supautils/issues/79

The `handle_alter_extension` and `handle_drop_extension` were using `run_process_utility_hook` various times unnecessarily.

Now this operation is clearly executed only once on each statement case.