### PR TITLE
refactor: deduplicate logic in create extension

### DIFF
--- a/src/privileged_extensions.h
+++ b/src/privileged_extensions.h
@@ -4,15 +4,16 @@
 #include "extensions_parameter_overrides.h"
 #include "utils.h"
 
-extern void handle_create_extension(
-    void (*process_utility_hook)(PROCESS_UTILITY_PARAMS),
-    PROCESS_UTILITY_PARAMS, const char *privileged_extensions,
-    const char *superuser,
-    const char *privileged_extensions_custom_scripts_path,
-    const extension_parameter_overrides *epos, const size_t total_epos);
-
 bool all_extensions_are_privileged(List *objects, const char *privileged_extensions);
 
 bool is_extension_privileged(const char *extname, const char *privileged_extensions);
+
+void run_global_before_create_script(char *extname, List *options, const char *privileged_extensions_custom_scripts_path);
+
+void run_ext_before_create_script(char *extname, List *options, const char *privileged_extensions_custom_scripts_path);
+
+void run_ext_after_create_script(char *extname, List *options, const char *privileged_extensions_custom_scripts_path);
+
+void override_create_ext_statement(CreateExtensionStmt *stmt, const size_t total_epos, const extension_parameter_overrides *epos);
 
 #endif

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -448,13 +448,29 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
 
       constrain_extension(stmt->extname, cexts, total_cexts);
 
-      handle_create_extension(prev_hook,
-                              PROCESS_UTILITY_ARGS,
-                              privileged_extensions,
-                              supautils_superuser,
-                              privileged_extensions_custom_scripts_path,
-                              epos, total_epos);
-      return;
+      if (is_extension_privileged(stmt->extname, privileged_extensions)) {
+         bool already_switched_to_superuser = false;
+
+         switch_to_superuser(supautils_superuser, &already_switched_to_superuser);
+
+         run_global_before_create_script(stmt->extname, stmt->options, privileged_extensions_custom_scripts_path);
+
+         run_ext_before_create_script(stmt->extname, stmt->options, privileged_extensions_custom_scripts_path);
+
+         override_create_ext_statement(stmt, total_epos, epos);
+
+         run_process_utility_hook(prev_hook);
+
+         run_ext_after_create_script(stmt->extname, stmt->options, privileged_extensions_custom_scripts_path);
+
+         if (!already_switched_to_superuser) {
+             switch_to_original_role();
+         }
+
+         return;
+      }
+
+      break;
   }
 
   /*


### PR DESCRIPTION
The `handle_create_extension` function repeated statements unnecessarily:

- switched to superuser multiple times
- downgraded to privileged role multiple times

The switching only needed to be done one time at the start, and downgrading one time at the end.

The same effect is maintained, no tests are broken.

Also `run_process_utility_hook` is now executed once for the `create extension` logic.

Partly addresses https://github.com/supabase/supautils/issues/79.