### PR TITLE
refactor: use C APIs on alter_owner instead of SPI 

### DIFF
--- a/src/pg_prelude.h
+++ b/src/pg_prelude.h
@@ -10,11 +10,15 @@
 #include <catalog/pg_authid.h>
 #include <catalog/pg_proc.h>
 #include <commands/defrem.h>
+#include <commands/publicationcmds.h>
+#include <commands/defrem.h>
+#include <commands/event_trigger.h>
 #include <executor/spi.h>
 #include <fmgr.h>
 #include <miscadmin.h>
 #include <nodes/makefuncs.h>
 #include <nodes/pg_list.h>
+#include <nodes/value.h>
 #include <parser/parse_func.h>
 #include <tcop/utility.h>
 #include <tsearch/ts_locale.h>

--- a/src/utils.h
+++ b/src/utils.h
@@ -107,7 +107,7 @@ typedef enum {
 
 extern void alter_owner(
     const char *obj_name,
-    const char *role_name,
+    Oid role_oid,
     altered_obj_type obj_type
 );
 

--- a/test/expected/event_triggers.out.in
+++ b/test/expected/event_triggers.out.in
@@ -87,16 +87,32 @@ NOTICE:  Skipping event trigger function "show_current_user" for user "postgres"
 DETAIL:  "postgres" is a superuser and the function "show_current_user" is not superuser-owned, it's owned by "privileged_role"
 \echo
 
--- extensions won't execute the event trigger function (since they're executed by superuser under our implementation)
-set role rolecreator;
-\echo
-
+-- creating extensions will not fire evtrigs
+set role privileged_role;
 create extension postgres_fdw;
 NOTICE:  Skipping event trigger function "show_current_user" for user "postgres"
 DETAIL:  "postgres" is a superuser and the function "show_current_user" is not superuser-owned, it's owned by "privileged_role"
 drop extension postgres_fdw;
 NOTICE:  Skipping event trigger function "show_current_user" for user "postgres"
 DETAIL:  "postgres" is a superuser and the function "show_current_user" is not superuser-owned, it's owned by "privileged_role"
+\echo
+
+-- creating fdws will not fire evtrigs
+create foreign data wrapper new_fdw;
+NOTICE:  Skipping event trigger function "show_current_user" for user "postgres"
+DETAIL:  "postgres" is a superuser and the function "show_current_user" is not superuser-owned, it's owned by "privileged_role"
+-- TODO: while correct, this is inconsistent as dropping the fdw does fire the evtrig for the privileged_role
+drop foreign data wrapper new_fdw;
+NOTICE:  the event trigger is executed for privileged_role
+\echo
+
+-- creating pubs will not fire evtrigs
+create publication p for all tables;
+NOTICE:  Skipping event trigger function "show_current_user" for user "postgres"
+DETAIL:  "postgres" is a superuser and the function "show_current_user" is not superuser-owned, it's owned by "privileged_role"
+-- TODO: while correct, this is inconsistent as dropping the publication does fire the evtrig for the privileged_role
+drop publication p;
+NOTICE:  the event trigger is executed for privileged_role
 \echo
 
 -- privesc shouldn't happen due to superuser tripping over a user-defined event trigger

--- a/test/expected/event_triggers_super.out
+++ b/test/expected/event_triggers_super.out
@@ -56,12 +56,24 @@ NOTICE:  superuser mandated event trigger: current_user is supabase_storage_admi
 
 -- creating extensions will fire superuser evtrigs
 set role privileged_role;
-\echo
-
 create extension postgres_fdw;
 NOTICE:  superuser mandated event trigger: current_user is postgres
 drop extension postgres_fdw;
 NOTICE:  superuser mandated event trigger: current_user is postgres
+\echo
+
+-- creating fdws will fire superuser evtrigs
+create foreign data wrapper new_fdw;
+NOTICE:  superuser mandated event trigger: current_user is postgres
+drop foreign data wrapper new_fdw;
+NOTICE:  superuser mandated event trigger: current_user is privileged_role
+\echo
+
+-- creating publications will fire superuser evtrigs
+create publication p for all tables;
+NOTICE:  superuser mandated event trigger: current_user is postgres
+drop publication p;
+NOTICE:  superuser mandated event trigger: current_user is privileged_role
 \echo
 
 -- a non-privileged role cannot alter a superuser owned evtrig

--- a/test/sql/event_triggers.sql
+++ b/test/sql/event_triggers.sql
@@ -71,12 +71,22 @@ set role postgres;
 create table super_stuff();
 \echo
 
--- extensions won't execute the event trigger function (since they're executed by superuser under our implementation)
-set role rolecreator;
-\echo
-
+-- creating extensions will not fire evtrigs
+set role privileged_role;
 create extension postgres_fdw;
 drop extension postgres_fdw;
+\echo
+
+-- creating fdws will not fire evtrigs
+create foreign data wrapper new_fdw;
+-- TODO: while correct, this is inconsistent as dropping the fdw does fire the evtrig for the privileged_role
+drop foreign data wrapper new_fdw;
+\echo
+
+-- creating pubs will not fire evtrigs
+create publication p for all tables;
+-- TODO: while correct, this is inconsistent as dropping the publication does fire the evtrig for the privileged_role
+drop publication p;
 \echo
 
 -- privesc shouldn't happen due to superuser tripping over a user-defined event trigger

--- a/test/sql/event_triggers_super.sql
+++ b/test/sql/event_triggers_super.sql
@@ -47,10 +47,18 @@ drop table storage_stuff;
 
 -- creating extensions will fire superuser evtrigs
 set role privileged_role;
-\echo
-
 create extension postgres_fdw;
 drop extension postgres_fdw;
+\echo
+
+-- creating fdws will fire superuser evtrigs
+create foreign data wrapper new_fdw;
+drop foreign data wrapper new_fdw;
+\echo
+
+-- creating publications will fire superuser evtrigs
+create publication p for all tables;
+drop publication p;
 \echo
 
 -- a non-privileged role cannot alter a superuser owned evtrig


### PR DESCRIPTION
The code is shorter and there's less room for error.

Also tests that evtrigs don't fire for all the non-superuser fdws and publications.