### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           # Copy files into directory structure
           mkdir -p ${package_dir}/usr/lib/postgresql/lib
           mkdir -p ${package_dir}/var/lib/postgresql/extension
-          cp build/*.so ${package_dir}/usr/lib/postgresql/lib
+          cp *.so ${package_dir}/usr/lib/postgresql/lib
 
           # symlinks to Copy files into directory structure
           mkdir -p ${package_dir}/usr/lib/postgresql/${{ matrix.postgres }}/lib


### PR DESCRIPTION
It failed with

```
cp: cannot stat 'build/*.so': No such file or directory
```

See https://github.com/supabase/supautils/actions/runs/15334351064/job/43148354327