### PR TITLE
Prevent dropping information_schema (fixes #69)

### DIFF
--- a/test/expected/privileged_role.out
+++ b/test/expected/privileged_role.out
@@ -246,3 +246,15 @@ drop cascades to function deny_drop_triggers.f()
 set role privileged_role;
 \echo
 
+-- all-role including superuser cannot drop information_schema
+set role postgres;
+create schema allow_drop_schema;
+drop schema information_schema;
+ERROR:  Cannot drop schema "information_schema"
+drop schema information_schema cascade;
+ERROR:  Cannot drop schema "information_schema"
+drop schema allow_drop_schema, information_schema;
+ERROR:  Cannot drop schema "information_schema"
+drop schema allow_drop_schema;
+\echo
+

--- a/test/sql/privileged_role.sql
+++ b/test/sql/privileged_role.sql
@@ -189,3 +189,12 @@ set role postgres;
 drop schema deny_drop_triggers cascade;
 set role privileged_role;
 \echo
+
+-- all-role including superuser cannot drop information_schema
+set role postgres;
+create schema allow_drop_schema;
+drop schema information_schema;
+drop schema information_schema cascade;
+drop schema allow_drop_schema, information_schema;
+drop schema allow_drop_schema;
+\echo


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature addition.

## What is the current behavior?

Currently, it is possible to run DROP SCHEMA information_schema, which removes information_schema. This behavior can cause severe and irreversible damage to the database.
Related issue: #69

## What is the new behavior?

With this PR, information_schema cannot be dropped anymore, even by a superuser. This ensures the integrity and stability of the database.

## Additional context

This PR addresses the request in #69 and provides protection against accidental or intentional removal of information_schema.
Test cases have been added and successfully verified.
