### PR TITLE
Make superuser option of AlterRoleStmt boolean

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -90,13 +90,17 @@ static void alter_role_super(const char* rolename, bool make_super){
   AlterRoleStmt *alter_stmt = makeNode(AlterRoleStmt);
   alter_stmt->role          = rolespec;
 
+#if PG15_GTE
   alter_stmt->options = list_make1(
-    makeDefElem("superuser", (Node *) makeInteger(make_super), -1) // using makeInteger because makeBoolean is not available on pg <= 14
+    makeDefElem("superuser", (Node *) makeBoolean(make_super), -1)
   );
 
-#if PG15_GTE
   AlterRole(NULL, alter_stmt);
 #else
+  alter_stmt->options = list_make1(
+    makeDefElem("superuser", (Node *) makeInteger(make_super), -1)
+  );
+
   AlterRole(alter_stmt);
 #endif
 


### PR DESCRIPTION
Postgres expect that the option is a boolean value.  Otherwise it crashes on a development environment with enabled asserts:

https://github.com/postgres/postgres/blob/REL_17_6/src/backend/commands/user.c#L864

## What kind of change does this PR introduce?

Bug fix to the `superuser` option of `AlterRoleStmt`.

## What is the current behavior?

## What is the new behavior?

Postgres crashes. Backtrace:

## Additional context

```
0   libsystem_kernel.dylib        	       0x19d2565b0 __pthread_kill + 8
1   libsystem_pthread.dylib       	       0x19d290888 pthread_kill + 296
2   libsystem_c.dylib             	       0x19d196808 abort + 124
3   postgres                      	       0x102bac8d4 ExceptionalCondition + 140 (assert.c:66)
4   postgres                      	       0x1028954bc AlterRole + 2188
5   supautils.dylib               	       0x103287800 alter_role_super + 128 (utils.c:98) [inlined]
6   supautils.dylib               	       0x103287800 alter_owner + 380 (utils.c:132)
7   supautils.dylib               	       0x103286960 supautils_hook + 2708 (supautils.c:880)
8   postgres                      	       0x102a7d9ec PortalRunUtility + 184 (pquery.c:1156)
9   postgres                      	       0x102a7d05c PortalRunMulti + 236 (pquery.c:1313)
10  postgres                      	       0x102a7ca94 PortalRun + 456 (pquery.c:789)
11  postgres                      	       0x102a7bb90 exec_simple_query + 1236 (postgres.c:1278)
12  postgres                      	       0x102a78ff4 PostgresMain + 1256
13  postgres                      	       0x102a75050 BackendMain + 140 (backend_startup.c:105)
14  postgres                      	       0x1029d8f28 postmaster_child_launch + 272 (launch_backend.c:277)
15  postgres                      	       0x1029dd2c4 BackendStartup + 300 (postmaster.c:3594) [inlined]
16  postgres                      	       0x1029dd2c4 ServerLoop + 7012 (postmaster.c:1676)
17  postgres                      	       0x1029daf40 PostmasterMain + 4472 (postmaster.c:1374)
18  postgres                      	       0x1028ff894 main + 1052 (main.c:199)
19  dyld                          	       0x19ced1d54 start + 7184
```
