### PR TITLE
fix: doing `xpg psql` failing

### DIFF
--- a/nix/xpg.nix
+++ b/nix/xpg.nix
@@ -3,8 +3,8 @@ let
   dep = fetchFromGitHub {
     owner  = "steve-chavez";
     repo   = "xpg";
-    rev    = "v1.4.1";
-    sha256 = "sha256-OI9g78KbguLh+ynOnRmnMM4lVOgNRAWkiI/YMmcMs+k=";
+    rev    = "v1.6.2";
+    sha256 = "sha256-97RHjB0xwWsSQQoI+KWw/WZ3h0OyKiYD1jLIq2kqx7k=";
   };
   xpg = import dep;
 in


### PR DESCRIPTION
The `contrib_regression` wasn't being created on the previous version of xpg. This updates it to a new patch version.