### PR TITLE
ci: release `.so` instead of `.deb`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,9 @@ jobs:
       matrix:
         extension_name:
           - supautils
-        postgres: [13, 14, 15, 16, 17]
+        postgres: [14, 15, 16, 17]
         box:
-          - { runner: ubuntu-latest, arch: amd64 }
-          - { runner: ubuntu-24.04-arm, arch: arm64 }
+          - { runner: ubuntu-22.04-arm, arch: arm64 }
     runs-on: ${{ matrix.box.runner }}
     steps:
       - uses: actions/checkout@v3
@@ -60,42 +59,6 @@ jobs:
           # Build supautils
           make
 
-          # name of the package directory before packaging
-          package_dir=${{ matrix.extension_name }}-${{ github.ref_name }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu
-
-          # Copy files into directory structure
-          mkdir -p ${package_dir}/usr/lib/postgresql/lib
-          mkdir -p ${package_dir}/var/lib/postgresql/extension
-          cp *.so ${package_dir}/usr/lib/postgresql/lib
-
-          # symlinks to Copy files into directory structure
-          mkdir -p ${package_dir}/usr/lib/postgresql/${{ matrix.postgres }}/lib
-          cd ${package_dir}/usr/lib/postgresql/${{ matrix.postgres }}/lib
-          cp -s ../../lib/*.so .
-          cd ../../../../../..
-
-          mkdir -p ${package_dir}/usr/share/postgresql/${{ matrix.postgres }}/extension
-          cd ${package_dir}/usr/share/postgresql/${{ matrix.postgres }}/extension
-          cd ../../../../../..
-
-          # Create install control file
-          extension_version=${{ github.ref_name }}
-          # strip the leading v
-          deb_version=${extension_version:1}
-
-          mkdir -p ${package_dir}/DEBIAN
-          touch ${package_dir}/DEBIAN/control
-          echo 'Package: ${{ matrix.extension_name }}' >> ${package_dir}/DEBIAN/control
-          echo 'Version:' ${deb_version} >> ${package_dir}/DEBIAN/control
-          echo 'Architecture: ${{ matrix.box.arch }}' >> ${package_dir}/DEBIAN/control
-          echo 'Maintainer: supabase' >> ${package_dir}/DEBIAN/control
-          echo 'Description: A PostgreSQL extension' >> ${package_dir}/DEBIAN/control
-
-          # Create deb package
-          sudo chown -R root:root ${package_dir}
-          sudo chmod -R 00755 ${package_dir}
-          sudo dpkg-deb --build --root-owner-group ${package_dir}
-
       - name: Get upload url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV
 
@@ -105,9 +68,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
-          asset_path: ./${{ matrix.extension_name }}-${{ github.ref_name }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu.deb
-          asset_name: ${{ matrix.extension_name }}-${{ github.ref_name }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu.deb
-          asset_content_type: application/vnd.debian.binary-package
+          asset_path: ./${{ matrix.extension_name }}.so
+          asset_name: ${{ matrix.extension_name }}-${{ github.ref_name }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu.so
+          asset_content_type: application/octet-stream
 
       - name: Configure aws credentials for uploading release artifacts
         if: ${{ matrix.box.arch == 'arm64' }}
@@ -119,4 +82,4 @@ jobs:
       - name: Upload release artifacts to S3
         if: ${{ matrix.box.arch == 'arm64' }}
         run: |
-          aws s3api put-object --bucket ${{ secrets.PROD_ARTIFACTS_BUCKET }} --key extensions/${{ matrix.extension_name }}-${{ github.ref_name }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu.deb --body ./${{ matrix.extension_name }}-${{ github.ref_name }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu.deb
+          aws s3api put-object --bucket ${{ secrets.PROD_ARTIFACTS_BUCKET }} --key extensions/${{ matrix.extension_name }}-${{ github.ref_name }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu.so --body ./${{ matrix.extension_name }}.so


### PR DESCRIPTION
We used to ship supautils as an extension so bundling it as a `.deb` was convenient to include all the `.sql` files. Now it's no longer necessary so just releasing the `.so` simplifies deployment.