### PR TITLE
chore: bump module version 3.2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PG_CFLAGS += --coverage
 endif
 
 MODULE_big = supautils
-MODVERSION = 3.1.1
+MODVERSION = 3.2.1
 
 SRC_DIR = src
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PG_CFLAGS += --coverage
 endif
 
 MODULE_big = supautils
-MODVERSION = 3.1.0
+MODVERSION = 3.1.1
 
 SRC_DIR = src
 


### PR DESCRIPTION
To release the change on https://github.com/supabase/supautils/pull/185/

This is just for the new `PG_MODULE_MAGIC_EXT`

https://github.com/supabase/supautils/blob/72dad9c8291645bf95784ca7bfc014cdce7887b7/src/supautils.c#L38
