### PR TITLE
Fix crash in supautils_executor_start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PG_CFLAGS += --coverage
 endif
 
 MODULE_big = supautils
-MODVERSION = 3.2.1
+MODVERSION = 3.2.2
 
 SRC_DIR = src
 

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -239,8 +239,9 @@ static void supautils_executor_start(QueryDesc *queryDesc, int eflags) {
                   quote_qualified_identifier(NULL, username);
 
               // Prevent memory leak of existing hint
-              if (edata->hint != NULL)
+              if (edata->hint != NULL) {
                 pfree(edata->hint);
+              }
 
               edata->hint = psprintf(
                   "Grant the required privileges to the current "
@@ -253,8 +254,9 @@ static void supautils_executor_start(QueryDesc *queryDesc, int eflags) {
               pfree(relname);
             }
 
-            if (schema != NULL)
+            if (schema != NULL) {
               pfree(schema);
+            }
           }
 
           destroyStringInfo(privileges_str);

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -218,7 +218,8 @@ static void supautils_executor_start(QueryDesc *queryDesc, int eflags) {
             find_missing_perm(queryDesc->plannedstmt, current_role_oid);
 
         if (missing.acl != 0 && OidIsValid(missing.relid) &&
-            (missing.acl & (ACL_TRUNCATE | ACL_TRIGGER | ACL_REFERENCES)) == 0) {
+            (missing.acl & (ACL_TRUNCATE | ACL_TRIGGER | ACL_REFERENCES)) ==
+                0) {
 
           StringInfo privileges_str = makeStringInfo();
           build_privileges_string(privileges_str, missing.acl);
@@ -228,9 +229,11 @@ static void supautils_executor_start(QueryDesc *queryDesc, int eflags) {
             char *relname = get_rel_name(missing.relid);
 
             if (relname != NULL) {
-              char *qualified_rel_name = quote_qualified_identifier(schema, relname);
+              char *qualified_rel_name =
+                  quote_qualified_identifier(schema, relname);
               char *username = GetUserNameFromId(current_role_oid, false);
-              char *quoted_role_name = quote_qualified_identifier(NULL, username);
+              char *quoted_role_name =
+                  quote_qualified_identifier(NULL, username);
 
               edata->hint = psprintf(
                   "Grant the required privileges to the current "

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -189,7 +189,6 @@ static void supautils_fmgr_hook(FmgrHookEventType event, FmgrInfo *flinfo,
 static void supautils_executor_start(QueryDesc *queryDesc, int eflags) {
   MemoryContext cur_ctx = CurrentMemoryContext;
 
-  // for performance in the case hint_roles is not configured
   if (hint_roles == NULL ||
       !is_hint_role(GetUserNameFromId(GetUserId(), false))) {
     if (prev_executor_start_hook)
@@ -204,16 +203,13 @@ static void supautils_executor_start(QueryDesc *queryDesc, int eflags) {
       else
         standard_ExecutorStart(queryDesc, eflags);
     }
-    // adds enhanced hints
     PG_CATCH();
     {
-      // we're on ErrorContext, we need to switch context because CopyErrorData
-      // fails due to an asssertion that it must not be in ErrorContext
       MemoryContext oldcxt = MemoryContextSwitchTo(cur_ctx);
       ErrorData    *edata  = CopyErrorData();
       MemoryContextSwitchTo(oldcxt);
 
-      FlushErrorState(); // should be called after CopyErrorData
+      FlushErrorState();
 
       if (edata->sqlerrcode == ERRCODE_INSUFFICIENT_PRIVILEGE) {
         const Oid current_role_oid = GetUserId();
@@ -222,8 +218,8 @@ static void supautils_executor_start(QueryDesc *queryDesc, int eflags) {
             find_missing_perm(queryDesc->plannedstmt, current_role_oid);
 
         if (missing.acl != 0 && OidIsValid(missing.relid) &&
-            (missing.acl & (ACL_TRUNCATE | ACL_TRIGGER | ACL_REFERENCES)) ==
-                0) {
+            (missing.acl & (ACL_TRUNCATE | ACL_TRIGGER | ACL_REFERENCES)) == 0) {
+
           StringInfo privileges_str = makeStringInfo();
           build_privileges_string(privileges_str, missing.acl);
 
@@ -232,34 +228,16 @@ static void supautils_executor_start(QueryDesc *queryDesc, int eflags) {
             char *relname = get_rel_name(missing.relid);
 
             if (relname != NULL) {
-              char *qualified_rel_name =
-                  quote_qualified_identifier(schema, relname);
+              char *qualified_rel_name = quote_qualified_identifier(schema, relname);
               char *username = GetUserNameFromId(current_role_oid, false);
-              char *quoted_role_name =
-                  quote_qualified_identifier(NULL, username);
-
-              // Prevent memory leak of existing hint
-              if (edata->hint != NULL) {
-                pfree(edata->hint);
-              }
+              char *quoted_role_name = quote_qualified_identifier(NULL, username);
 
               edata->hint = psprintf(
                   "Grant the required privileges to the current "
                   "role with: GRANT %s ON %s TO %s;",
                   privileges_str->data, qualified_rel_name, quoted_role_name);
-
-              pfree(username);
-              pfree(qualified_rel_name);
-              pfree(quoted_role_name);
-              pfree(relname);
-            }
-
-            if (schema != NULL) {
-              pfree(schema);
             }
           }
-
-          destroyStringInfo(privileges_str);
         }
       }
 

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -243,20 +243,32 @@ static void supautils_executor_start(QueryDesc *queryDesc, int eflags) {
 
         char *schema  = get_namespace_name(get_rel_namespace(missing.relid));
         char *relname = get_rel_name(missing.relid);
-        char *qualified_rel_name = quote_qualified_identifier(schema, relname);
-        char *quoted_role_name   = quote_qualified_identifier(
-            NULL, GetUserNameFromId(current_role_oid, false));
 
-        edata->hint = psprintf("Grant the required privileges to the current "
-                               "role with: GRANT %s ON %s TO %s;",
-                               privileges_str->data, qualified_rel_name,
-                               quoted_role_name);
+        if (relname != NULL) {
+          char *qualified_rel_name =
+              quote_qualified_identifier(schema, relname);
+
+          char *username         = GetUserNameFromId(current_role_oid, false);
+          char *quoted_role_name = quote_qualified_identifier(NULL, username);
+
+          // Free the hint if it is present. Otherwise we'll leak the old one
+          if (edata->hint != NULL) pfree(edata->hint);
+
+          edata->hint = psprintf("Grant the required privileges to the current "
+                                 "role with: GRANT %s ON %s TO %s;",
+                                 privileges_str->data, qualified_rel_name,
+                                 quoted_role_name);
+
+          // Clean up what we can here
+          pfree(username);
+          pfree(qualified_rel_name);
+          pfree(quoted_role_name);
+          pfree(relname);
+        }
 
         destroyStringInfo(privileges_str);
-        pfree(schema);
-        pfree(relname);
-        pfree(qualified_rel_name);
-        pfree(quoted_role_name);
+
+        if (schema != NULL) pfree(schema);
       }
 
       ReThrowError(edata);

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -218,57 +218,47 @@ static void supautils_executor_start(QueryDesc *queryDesc, int eflags) {
       if (edata->sqlerrcode == ERRCODE_INSUFFICIENT_PRIVILEGE) {
         const Oid current_role_oid = GetUserId();
 
-        // edata->table_name is always NULL for some reason, so we need to find
-        // the relid (included in missing_perm)
         missing_perm missing =
             find_missing_perm(queryDesc->plannedstmt, current_role_oid);
 
-        // there must be some privilege missing given there was a
-        // ERRCODE_INSUFFICIENT_PRIVILEGE
-        Assert(missing.acl != 0);
-        Assert(missing.relid != InvalidOid);
+        if (missing.acl != 0 && OidIsValid(missing.relid) &&
+            (missing.acl & (ACL_TRUNCATE | ACL_TRIGGER | ACL_REFERENCES)) ==
+                0) {
+          StringInfo privileges_str = makeStringInfo();
+          build_privileges_string(privileges_str, missing.acl);
 
-        // ERRCODE_INSUFFICIENT_PRIVILEGE also includes TRUNCATE, REFERENCES and
-        // TRIGGER error privileges but these are not visible in this function
-        // (a ExecutorStart_hook) so we assert here that these are impossible as
-        // a missing privilege
-        Assert((missing.acl & (ACL_TRUNCATE | ACL_TRIGGER | ACL_REFERENCES)) ==
-               0);
+          if (privileges_str->len > 0) {
+            char *schema = get_namespace_name(get_rel_namespace(missing.relid));
+            char *relname = get_rel_name(missing.relid);
 
-        StringInfo privileges_str = makeStringInfo();
-        build_privileges_string(privileges_str, missing.acl);
+            if (relname != NULL) {
+              char *qualified_rel_name =
+                  quote_qualified_identifier(schema, relname);
+              char *username = GetUserNameFromId(current_role_oid, false);
+              char *quoted_role_name =
+                  quote_qualified_identifier(NULL, username);
 
-        // the string of privileges has to be built
-        Assert(privileges_str->len > 0);
+              // Prevent memory leak of existing hint
+              if (edata->hint != NULL)
+                pfree(edata->hint);
 
-        char *schema  = get_namespace_name(get_rel_namespace(missing.relid));
-        char *relname = get_rel_name(missing.relid);
+              edata->hint = psprintf(
+                  "Grant the required privileges to the current "
+                  "role with: GRANT %s ON %s TO %s;",
+                  privileges_str->data, qualified_rel_name, quoted_role_name);
 
-        if (relname != NULL) {
-          char *qualified_rel_name =
-              quote_qualified_identifier(schema, relname);
+              pfree(username);
+              pfree(qualified_rel_name);
+              pfree(quoted_role_name);
+              pfree(relname);
+            }
 
-          char *username         = GetUserNameFromId(current_role_oid, false);
-          char *quoted_role_name = quote_qualified_identifier(NULL, username);
+            if (schema != NULL)
+              pfree(schema);
+          }
 
-          // Free the hint if it is present. Otherwise we'll leak the old one
-          if (edata->hint != NULL) pfree(edata->hint);
-
-          edata->hint = psprintf("Grant the required privileges to the current "
-                                 "role with: GRANT %s ON %s TO %s;",
-                                 privileges_str->data, qualified_rel_name,
-                                 quoted_role_name);
-
-          // Clean up what we can here
-          pfree(username);
-          pfree(qualified_rel_name);
-          pfree(quoted_role_name);
-          pfree(relname);
+          destroyStringInfo(privileges_str);
         }
-
-        destroyStringInfo(privileges_str);
-
-        if (schema != NULL) pfree(schema);
       }
 
       ReThrowError(edata);

--- a/test/expected/permission_hints.out.in
+++ b/test/expected/permission_hints.out.in
@@ -13,9 +13,23 @@ end;
 $$;
 create table referencing_hint(id int);
 alter table referencing_hint owner to hint_role;
+create function test_fnc()
+    returns void
+    language plpgsql as
+$fnc$
+begin
+end;
+$fnc$;
+revoke execute on function test_fnc() from public;
+alter function test_fnc() owner to non_hint_role;
 \echo
 
 set role hint_role;
+\echo
+
+-- function with no permissions
+select test_fnc();
+ERROR:  permission denied for function test_fnc
 \echo
 
 -- no column selected
@@ -137,6 +151,7 @@ ERROR:  permission denied for table hint_target
 
 reset role;
 drop table referencing_hint;
+drop function test_fnc();
 drop role hint_role;
 drop role non_hint_role;
 drop function hint_fn();

--- a/test/sql/permission_hints.sql
+++ b/test/sql/permission_hints.sql
@@ -12,10 +12,25 @@ begin
 end;
 $$;
 create table referencing_hint(id int);
+
 alter table referencing_hint owner to hint_role;
+
+create function test_fnc()
+    returns void
+    language plpgsql as
+$fnc$
+begin
+end;
+$fnc$;
+revoke execute on function test_fnc() from public;
+alter function test_fnc() owner to non_hint_role;
 \echo
 
 set role hint_role;
+\echo
+
+-- function with no permissions
+select test_fnc();
 \echo
 
 -- no column selected
@@ -97,6 +112,7 @@ select from hint_target;
 
 reset role;
 drop table referencing_hint;
+drop function test_fnc();
 drop role hint_role;
 drop role non_hint_role;
 drop function hint_fn();


### PR DESCRIPTION
`supautils_executor_start` makes some assumptions about the `ERROR` it is intercepting. Following are addressed:

- Fixed cases where the target object isn't a relation
- Fixed possible cases of trying to free a `NULL` variable
- Fixed possible leak of an old hint (if there were one)

This fixes existing bugs. However it doesn't add the missing functionality for the cases when privileges are missing for functions, schemas etc.

I also want to point out that executor is a very low level API and hooking into it merely to slightly improve user experience seems like an overkill to me. We could consider writing a standalone function to the effect of `check_permissions(objclassid, objid, rolename)` that would perform the same checks as the hook, but won't reside in a critical codepath so any potential bugs won't crash the database.