### PR TITLE
chore(ci): print checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,10 @@ jobs:
         run: |
           tar -cJf supautils-${{ github.ref_name }}-arm64.tar.xz *-arm64-*.so
           tar -cJf supautils-${{ github.ref_name }}-amd64.tar.xz *-amd64-*.so
+          echo '### SHA256 checksums' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          sha256sum *.tar.xz | tee -a $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: GitHub OIDC Auth
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

getting the sha256sum of *.tar.xz artifacts require AWS access

## What is the new behavior?

print these checksums here instead so we can immediately use it in supautils deployment
