### PR TITLE
test: against pg core regress tests for 15 to 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,36 @@ jobs:
       - if: ${{ failure() }}
         run: cat regression.diffs
 
+  test-core:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pg-version: ['15', '16', '17', '18']
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe # v31.10.3
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Use Cachix Cache
+        uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
+        with:
+          name: nxpg
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build
+        run: nix-shell --run "xpg -v ${{ matrix.pg-version }} build"
+
+      - name: Run tests
+        run: nix-shell --run "xpg -v ${{ matrix.pg-version }} test-core"
+
+      - if: ${{ failure() }}
+        run: cat regression.diffs
+
   test-on-macos:
     runs-on: macos-15
 

--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,32 @@ endif
 # extra dep for target in pgxs.mk
 installcheck: $(GENERATED_OUT)
 
+CORE_STAGEDIR = $(BUILD_DIR)/$(notdir $(PG_REGRESS_TESTS))
+ifeq ($(PG_EQ15), 0)
+CORE_PATCHES = test/core_patches/15_create_role.out.patch \
+	test/core_patches/15_guc.out.patch \
+	test/core_patches/15_plpgsql.out.patch
+else ifeq ($(PG_GE16), 0)
+CORE_PATCHES = test/core_patches/ge16_create_role.out.patch
+endif
+
+$(CORE_STAGEDIR)/parallel_schedule: $(CORE_PATCHES)
+	rm -rf $(CORE_STAGEDIR)
+	mkdir -p $(CORE_STAGEDIR)/sql $(CORE_STAGEDIR)/expected $(CORE_STAGEDIR)/data
+	cp -R $(PG_REGRESS_TESTS)/sql/. $(CORE_STAGEDIR)/sql/
+	cp -R $(PG_REGRESS_TESTS)/expected/. $(CORE_STAGEDIR)/expected/
+	cp -R $(PG_REGRESS_TESTS)/data/. $(CORE_STAGEDIR)/data/
+	cp $(PG_REGRESS_TESTS)/parallel_schedule $(CORE_STAGEDIR)/
+	if test -f $(PG_REGRESS_TESTS)/init.conf; then cp $(PG_REGRESS_TESTS)/init.conf $(CORE_STAGEDIR)/; fi
+	@set -e; \
+	for patch in $(CORE_PATCHES); do \
+		patch -d $(CORE_STAGEDIR) -p1 < $$patch; \
+	done
+
+.PHONY: test-core
+test-core: $(CORE_STAGEDIR)/parallel_schedule
+	$(pg_regress_installcheck) --dlpath=$(PG_REGRESS_TESTS)/lib --inputdir=$(CORE_STAGEDIR) --schedule=$(CORE_STAGEDIR)/parallel_schedule --dbname=regression
+
 .PHONY: test
 test:
 	make installcheck

--- a/README.md
+++ b/README.md
@@ -365,6 +365,17 @@ To test with a postgres built with assertions enabled:
 $ xpg -v 17 --cassert test
 ```
 
+### Regress testing against PostgreSQL core
+
+Since supautils modifies default postgres behavior with hooks, we need to test exactly what it changes and see if we don't break existing functionality.
+For this you can use:
+
+```
+xpg -v 15 test-core
+```
+
+Works on pg 15, 16, 17 and 18.
+
 ### Coverage
 
 For coverage, execute:

--- a/flake.lock
+++ b/flake.lock
@@ -43,16 +43,16 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1778705163,
-        "narHash": "sha256-fCZFKnoE5zYoEMSEDLYZ87RELO8PYcVjATmnQZhRtAQ=",
+        "lastModified": 1779917553,
+        "narHash": "sha256-Gtsvs1StmiczcRe9PZXKTvDktvPYorKsdfsw1HRljSc=",
         "owner": "steve-chavez",
         "repo": "xpg",
-        "rev": "c92037ecab9b368aa233c908d4d978c465bb82de",
+        "rev": "efb20cca11a29a5d682dedac8e93debc92792b02",
         "type": "github"
       },
       "original": {
         "owner": "steve-chavez",
-        "ref": "v2.1.0",
+        "ref": "v2.2.0",
         "repo": "xpg",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/91c9a64ce2a84e648d0cf9671274bb9c2fb9ba60";
     xpg = {
-      url = "github:steve-chavez/xpg/v2.1.0";
+      url = "github:steve-chavez/xpg/v2.2.0";
     };
   };
 

--- a/test/core_patches/15_create_role.out.patch
+++ b/test/core_patches/15_create_role.out.patch
@@ -1,0 +1,37 @@
+# These failures are expected due to the reserved memberships and reserved roles
+--- a/expected/create_role.out
++++ b/expected/create_role.out
+@@ -4,7 +4,8 @@
+ -- fail, only superusers can create users with these privileges
+ SET SESSION AUTHORIZATION regress_role_admin;
+ CREATE ROLE regress_nosuch_superuser SUPERUSER;
+-ERROR:  must be superuser to create superusers
++ERROR:  permission denied to create role
++DETAIL:  Only roles with the SUPERUSER attribute may create roles with the SUPERUSER attribute.
+ CREATE ROLE regress_nosuch_replication_bypassrls REPLICATION BYPASSRLS;
+ ERROR:  must be superuser to create replication users
+ CREATE ROLE regress_nosuch_replication REPLICATION;
+@@ -82,8 +83,11 @@
+ CREATE ROLE regress_read_all_stats IN ROLE pg_read_all_stats;
+ CREATE ROLE regress_stat_scan_tables IN ROLE pg_stat_scan_tables;
+ CREATE ROLE regress_read_server_files IN ROLE pg_read_server_files;
++ERROR:  "pg_read_server_files" role memberships are reserved, only superusers can grant them
+ CREATE ROLE regress_write_server_files IN ROLE pg_write_server_files;
++ERROR:  "pg_write_server_files" role memberships are reserved, only superusers can grant them
+ CREATE ROLE regress_execute_server_program IN ROLE pg_execute_server_program;
++ERROR:  "pg_execute_server_program" role memberships are reserved, only superusers can grant them
+ CREATE ROLE regress_signal_backend IN ROLE pg_signal_backend;
+ -- fail, creation of these roles failed above so they do not now exist
+ SET SESSION AUTHORIZATION regress_role_admin;
+@@ -123,8 +127,11 @@
+ DROP ROLE regress_read_all_stats;
+ DROP ROLE regress_stat_scan_tables;
+ DROP ROLE regress_read_server_files;
++ERROR:  role "regress_read_server_files" does not exist
+ DROP ROLE regress_write_server_files;
++ERROR:  role "regress_write_server_files" does not exist
+ DROP ROLE regress_execute_server_program;
++ERROR:  role "regress_execute_server_program" does not exist
+ DROP ROLE regress_signal_backend;
+ -- fail, role still owns database objects
+ DROP ROLE regress_tenant;

--- a/test/core_patches/15_guc.out.patch
+++ b/test/core_patches/15_guc.out.patch
@@ -1,0 +1,15 @@
+# TODO Find out why this happens, see results/guc.out after running `xpg -v15 test-core`
+--- a/expected/guc.out
++++ b/expected/guc.out
+@@ -551,9 +551,9 @@
+ -- Check what happens when you try to set a "custom" GUC within the
+ -- namespace of an extension.
+ SET plpgsql.extra_foo_warnings = true;  -- allowed if plpgsql is not loaded yet
++ERROR:  invalid configuration parameter name "plpgsql.extra_foo_warnings"
++DETAIL:  "plpgsql" is a reserved prefix.
+ LOAD 'plpgsql';  -- this will throw a warning and delete the variable
+-WARNING:  invalid configuration parameter name "plpgsql.extra_foo_warnings", removing it
+-DETAIL:  "plpgsql" is now a reserved prefix.
+ SET plpgsql.extra_foo_warnings = true;  -- now, it's an error
+ ERROR:  invalid configuration parameter name "plpgsql.extra_foo_warnings"
+ DETAIL:  "plpgsql" is a reserved prefix.

--- a/test/core_patches/15_plpgsql.out.patch
+++ b/test/core_patches/15_plpgsql.out.patch
@@ -1,0 +1,12 @@
+# TODO Find out why this happens, see results/plpgsql.out after running `xpg -v15 test-core`
+--- a/expected/plpgsql.out
++++ b/expected/plpgsql.out
+@@ -2188,0 +2189,3 @@
++WARNING:  cursor "rc" is not closed
++DETAIL:  PL/pgSQL function return_unnamed_refcursor() line 5 at OPEN
++PL/pgSQL function use_refcursor(refcursor) line 6 at assignment
+@@ -2219,0 +2223,4 @@
++WARNING:  cursor "rc" is not closed
++DETAIL:  PL/pgSQL function return_refcursor(refcursor) line 3 at OPEN
++SQL statement "SELECT return_refcursor($1)"
++PL/pgSQL function refcursor_test1(refcursor) line 3 at PERFORM

--- a/test/core_patches/ge16_create_role.out.patch
+++ b/test/core_patches/ge16_create_role.out.patch
@@ -1,0 +1,21 @@
+# These failures are expected due to the reserved memberships feature
+--- a/expected/create_role.out
++++ b/expected/create_role.out
+@@ -184,14 +184,11 @@
+ ERROR:  permission denied to grant role "pg_stat_scan_tables"
+ DETAIL:  Only roles with the ADMIN option on role "pg_stat_scan_tables" may grant this role.
+ CREATE ROLE regress_read_server_files IN ROLE pg_read_server_files;
+-ERROR:  permission denied to grant role "pg_read_server_files"
+-DETAIL:  Only roles with the ADMIN option on role "pg_read_server_files" may grant this role.
++ERROR:  "pg_read_server_files" role memberships are reserved, only superusers can grant them
+ CREATE ROLE regress_write_server_files IN ROLE pg_write_server_files;
+-ERROR:  permission denied to grant role "pg_write_server_files"
+-DETAIL:  Only roles with the ADMIN option on role "pg_write_server_files" may grant this role.
++ERROR:  "pg_write_server_files" role memberships are reserved, only superusers can grant them
+ CREATE ROLE regress_execute_server_program IN ROLE pg_execute_server_program;
+-ERROR:  permission denied to grant role "pg_execute_server_program"
+-DETAIL:  Only roles with the ADMIN option on role "pg_execute_server_program" may grant this role.
++ERROR:  "pg_execute_server_program" role memberships are reserved, only superusers can grant them
+ CREATE ROLE regress_signal_backend IN ROLE pg_signal_backend;
+ ERROR:  permission denied to grant role "pg_signal_backend"
+ DETAIL:  Only roles with the ADMIN option on role "pg_signal_backend" may grant this role.


### PR DESCRIPTION
Solves https://github.com/supabase/supautils/issues/101.

By doing `xpg -v <ver> test-core` you can run pg core regress tests against supautils. This only works starting from pg 15 through 18.

With this we can see how supautils diverges from postgres core behavior and prevent bugs like https://github.com/supabase/supautils/pull/190. Look at the `test/core_patches` files for the differences.

If `xpg -v <ver> test-core` fails you can see the failures as usual on `regress.diffs` and go to individual files in `results/*.out`.