### PR TITLE
fix: late validation on supautils.constrained_extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,6 @@ PG_CFLAGS = -std=c11 -Wextra -Wall -Werror \
 	-Wno-vla \
 	-Wno-long-long
 
-ifeq ($(TEST), 1)
-PG_CFLAGS += -DTEST=1
-endif
-
 ifeq ($(TEST_CORE), 1)
 PG_CFLAGS += -DTEST_CORE=1
 endif

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PG_CFLAGS += --coverage
 endif
 
 MODULE_big = supautils
-MODVERSION = 3.2.2
+MODVERSION = 3.2.3
 
 SRC_DIR = src
 

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -1161,24 +1161,54 @@ static void check_parameter(char *val, char *name) {
   }
 }
 
-static void
-constrained_extensions_assign_hook(const char                   *newval,
-                                   __attribute__((unused)) void *extra) {
+static void clear_constrained_extensions(void) {
   if (total_cexts > 0) {
     for (size_t i = 0; i < total_cexts; i++) {
       pfree(cexts[i].name);
     }
-    total_cexts = 0;
   }
-  if (newval) {
+  memset(cexts, 0, sizeof(cexts));
+  total_cexts = 0;
+}
+
+static bool
+constrained_extensions_check_hook(char                            **newval,
+                                  __attribute__((unused)) void    **extra,
+                                  __attribute__((unused)) GucSource source) {
+  constrained_extension tmp_cexts[MAX_CONSTRAINED_EXTENSIONS] = {0};
+
+  if (*newval) {
     json_constrained_extension_parse_state state =
-        parse_constrained_extensions(newval, cexts);
-    total_cexts = state.total_cexts;
+        parse_constrained_extensions(*newval, tmp_cexts);
+
+    for (int i = 0; i < state.total_cexts; i++) {
+      pfree(tmp_cexts[i].name);
+    }
+
     if (state.error_msg) {
       ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                       errmsg("supautils.constrained_extensions: %s",
                              state.error_msg)));
     }
+  }
+
+  return true;
+}
+
+static void
+constrained_extensions_assign_hook(const char                   *newval,
+                                   __attribute__((unused)) void *extra) {
+  clear_constrained_extensions();
+
+  if (newval) {
+    json_constrained_extension_parse_state state =
+        parse_constrained_extensions(newval, cexts);
+    if (state.error_msg) {
+      ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                      errmsg("supautils.constrained_extensions: %s",
+                             state.error_msg)));
+    }
+    total_cexts = state.total_cexts;
   }
 }
 
@@ -1446,7 +1476,7 @@ void _PG_init(void) {
                              "Extensions that require a minimum amount of "
                              "CPUs, memory and free disk to be installed",
                              NULL, &constrained_extensions_str, NULL,
-                             SUPAUTILS_GUC_CONTEXT_SIGHUP, 0, NULL,
+                             PGC_SIGHUP, 0, constrained_extensions_check_hook,
                              constrained_extensions_assign_hook, NULL);
 
   DefineCustomStringVariable("supautils.drop_trigger_grants",

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -1018,22 +1018,51 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
   run_process_utility_hook(prev_hook);
 }
 
+static void clear_extensions_parameter_overrides_array(
+    extension_parameter_overrides *target, size_t count) {
+  for (size_t i = 0; i < count; i++) {
+    if (target[i].name != NULL) pfree(target[i].name);
+    if (target[i].schema != NULL) pfree(target[i].schema);
+  }
+  memset(target, 0, sizeof(extension_parameter_overrides) * count);
+}
+
+static void clear_extensions_parameter_overrides(void) {
+  clear_extensions_parameter_overrides_array(
+      epos, MAX_EXTENSIONS_PARAMETER_OVERRIDES);
+  total_epos = 0;
+}
+
 static bool extensions_parameter_overrides_check_hook(
     char **newval, __attribute__((unused)) void **extra,
     __attribute__((unused)) GucSource source) {
-  char *val = *newval;
+  extension_parameter_overrides tmp_epos[MAX_EXTENSIONS_PARAMETER_OVERRIDES] = {
+    0};
 
-  if (total_epos > 0) {
-    for (size_t i = 0; i < total_epos; i++) {
-      pfree(epos[i].name);
-      pfree(epos[i].schema);
+  if (*newval) {
+    json_extension_parameter_overrides_parse_state state =
+        parse_extensions_parameter_overrides(*newval, tmp_epos);
+
+    clear_extensions_parameter_overrides_array(
+        tmp_epos, MAX_EXTENSIONS_PARAMETER_OVERRIDES);
+
+    if (state.error_msg) {
+      ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                      errmsg("supautils.extensions_parameter_overrides: %s",
+                             state.error_msg)));
     }
-    total_epos = 0;
   }
 
-  if (val) {
+  return true;
+}
+
+static void extensions_parameter_overrides_assign_hook(
+    const char *newval, __attribute__((unused)) void *extra) {
+  clear_extensions_parameter_overrides();
+
+  if (newval) {
     json_extension_parameter_overrides_parse_state state =
-        parse_extensions_parameter_overrides(val, epos);
+        parse_extensions_parameter_overrides(newval, epos);
     if (state.error_msg) {
       ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                       errmsg("supautils.extensions_parameter_overrides: %s",
@@ -1041,8 +1070,6 @@ static bool extensions_parameter_overrides_check_hook(
     }
     total_epos = state.total_epos;
   }
-
-  return true;
 }
 
 static bool policy_grants_check_hook(char                            **newval,
@@ -1393,11 +1420,12 @@ void _PG_init(void) {
   prev_executor_start_hook = ExecutorStart_hook;
   ExecutorStart_hook       = supautils_executor_start;
 
-  DefineCustomStringVariable(
-      "supautils.extensions_parameter_overrides",
-      "Overrides for CREATE EXTENSION parameters", NULL,
-      &extensions_parameter_overrides_str, NULL, PGC_SIGHUP, 0,
-      &extensions_parameter_overrides_check_hook, NULL, NULL);
+  DefineCustomStringVariable("supautils.extensions_parameter_overrides",
+                             "Overrides for CREATE EXTENSION parameters", NULL,
+                             &extensions_parameter_overrides_str, NULL,
+                             PGC_SIGHUP, 0,
+                             &extensions_parameter_overrides_check_hook,
+                             &extensions_parameter_overrides_assign_hook, NULL);
 
   DefineCustomStringVariable(
       "supautils.reserved_roles",

--- a/src/utils.h
+++ b/src/utils.h
@@ -12,13 +12,6 @@
 #include <utils/acl.h>
 #include <utils/queryenvironment.h>
 
-// helper for testing a guc config
-#if TEST
-#  define SUPAUTILS_GUC_CONTEXT_SIGHUP PGC_USERSET
-#else
-#  define SUPAUTILS_GUC_CONTEXT_SIGHUP PGC_SIGHUP
-#endif
-
 /**
  * Switch to a superuser and save the original role. Caller is responsible for
  * calling switch_to_original_role() afterwards.

--- a/test/expected/extension_parameter_override.out
+++ b/test/expected/extension_parameter_override.out
@@ -1,3 +1,20 @@
+-- check json validation works
+alter system set supautils.extensions_parameter_overrides to '';
+ERROR:  supautils.extensions_parameter_overrides: invalid json
+alter system set supautils.extensions_parameter_overrides to '[]';
+ERROR:  supautils.extensions_parameter_overrides: unexpected array
+alter system set supautils.extensions_parameter_overrides to '1';
+ERROR:  supautils.extensions_parameter_overrides: unexpected scalar, expected an object
+alter system set supautils.extensions_parameter_overrides to '{"sslinfo": 123}';
+ERROR:  supautils.extensions_parameter_overrides: unexpected scalar, expected an object
+alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"schema": {}}}';
+ERROR:  supautils.extensions_parameter_overrides: unexpected object for schema, expected a value
+alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"version": "1.0"}}';
+ERROR:  supautils.extensions_parameter_overrides: unexpected field, only schema is allowed
+alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"schema": 123}}';
+ERROR:  supautils.extensions_parameter_overrides: unexpected schema value, expected a string
+\echo
+
 -- can force sslinfo to be installed in pg_catalog
 create extension sslinfo schema public;
 select extnamespace::regnamespace from pg_extension where extname = 'sslinfo';

--- a/test/expected/linux_constrained_extensions.out
+++ b/test/expected/linux_constrained_extensions.out
@@ -28,27 +28,27 @@ create extension bloom;
 \echo
 
 -- check json validation works
-set supautils.constrained_extensions to '';
+alter system set supautils.constrained_extensions to '';
 ERROR:  supautils.constrained_extensions: invalid json
-set supautils.constrained_extensions to '[]';
+alter system set supautils.constrained_extensions to '[]';
 ERROR:  supautils.constrained_extensions: unexpected array
-set supautils.constrained_extensions to '1';
+alter system set supautils.constrained_extensions to '1';
 ERROR:  supautils.constrained_extensions: unexpected scalar, expected an object
-set supautils.constrained_extensions to '"foo"';
+alter system set supautils.constrained_extensions to '"foo"';
 ERROR:  supautils.constrained_extensions: unexpected scalar, expected an object
-set supautils.constrained_extensions to '{"plrust": []}';
+alter system set supautils.constrained_extensions to '{"plrust": []}';
 ERROR:  supautils.constrained_extensions: unexpected array
-set supautils.constrained_extensions to '{"plrust": {"cpu": true}}';
+alter system set supautils.constrained_extensions to '{"plrust": {"cpu": true}}';
 ERROR:  supautils.constrained_extensions: unexpected cpu value, expected a number
-set supautils.constrained_extensions to '{"plrust": {"cpu": {}}}';
+alter system set supautils.constrained_extensions to '{"plrust": {"cpu": {}}}';
 ERROR:  supautils.constrained_extensions: unexpected object for cpu, mem or disk, expected a value
-set supautils.constrained_extensions to '{"plrust": {"anykey": "11GB"}}';
+alter system set supautils.constrained_extensions to '{"plrust": {"anykey": "11GB"}}';
 ERROR:  supautils.constrained_extensions: unexpected field, only cpu, mem or disk are allowed
-set supautils.constrained_extensions to '{"plrust": {"disk": 123}}';
+alter system set supautils.constrained_extensions to '{"plrust": {"disk": 123}}';
 ERROR:  supautils.constrained_extensions: unexpected disk value, expected a string with bytes in human-readable format (as returned by pg_size_pretty)
-set supautils.constrained_extensions to '{"plrust": {"mem": 456}}';
+alter system set supautils.constrained_extensions to '{"plrust": {"mem": 456}}';
 ERROR:  supautils.constrained_extensions: unexpected mem value, expected a string with bytes in human-readable format (as returned by pg_size_pretty)
-set supautils.constrained_extensions to '{"plrust": {"mem": ""}}';
+alter system set supautils.constrained_extensions to '{"plrust": {"mem": ""}}';
 ERROR:  invalid size: ""
-set supautils.constrained_extensions to '{"plrust": 123}';
+alter system set supautils.constrained_extensions to '{"plrust": 123}';
 ERROR:  supautils.constrained_extensions: unexpected scalar, expected an object

--- a/test/sql/extension_parameter_override.sql
+++ b/test/sql/extension_parameter_override.sql
@@ -1,3 +1,13 @@
+-- check json validation works
+alter system set supautils.extensions_parameter_overrides to '';
+alter system set supautils.extensions_parameter_overrides to '[]';
+alter system set supautils.extensions_parameter_overrides to '1';
+alter system set supautils.extensions_parameter_overrides to '{"sslinfo": 123}';
+alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"schema": {}}}';
+alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"version": "1.0"}}';
+alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"schema": 123}}';
+\echo
+
 -- can force sslinfo to be installed in pg_catalog
 create extension sslinfo schema public;
 select extnamespace::regnamespace from pg_extension where extname = 'sslinfo';

--- a/test/sql/linux_constrained_extensions.sql
+++ b/test/sql/linux_constrained_extensions.sql
@@ -19,15 +19,15 @@ create extension bloom;
 \echo
 
 -- check json validation works
-set supautils.constrained_extensions to '';
-set supautils.constrained_extensions to '[]';
-set supautils.constrained_extensions to '1';
-set supautils.constrained_extensions to '"foo"';
-set supautils.constrained_extensions to '{"plrust": []}';
-set supautils.constrained_extensions to '{"plrust": {"cpu": true}}';
-set supautils.constrained_extensions to '{"plrust": {"cpu": {}}}';
-set supautils.constrained_extensions to '{"plrust": {"anykey": "11GB"}}';
-set supautils.constrained_extensions to '{"plrust": {"disk": 123}}';
-set supautils.constrained_extensions to '{"plrust": {"mem": 456}}';
-set supautils.constrained_extensions to '{"plrust": {"mem": ""}}';
-set supautils.constrained_extensions to '{"plrust": 123}';
+alter system set supautils.constrained_extensions to '';
+alter system set supautils.constrained_extensions to '[]';
+alter system set supautils.constrained_extensions to '1';
+alter system set supautils.constrained_extensions to '"foo"';
+alter system set supautils.constrained_extensions to '{"plrust": []}';
+alter system set supautils.constrained_extensions to '{"plrust": {"cpu": true}}';
+alter system set supautils.constrained_extensions to '{"plrust": {"cpu": {}}}';
+alter system set supautils.constrained_extensions to '{"plrust": {"anykey": "11GB"}}';
+alter system set supautils.constrained_extensions to '{"plrust": {"disk": 123}}';
+alter system set supautils.constrained_extensions to '{"plrust": {"mem": 456}}';
+alter system set supautils.constrained_extensions to '{"plrust": {"mem": ""}}';
+alter system set supautils.constrained_extensions to '{"plrust": 123}';


### PR DESCRIPTION
Note: this also adds a second fix for [supautils.extensions_parameter_overrides](https://github.com/supabase/supautils/pull/202/commits/c6414b8458b8d5aacfeedc85646e11c0ae6ddba6), which follows the same logic.

---

`supautils.constrained_extensions` ([ref](https://github.com/supabase/supautils#constrained-extensions)) was using the `assign_hook` to do validation but it's a bad place because it runs too late.

So when you do:

```sql
-- this is invalid but it's allowed first time
alter system  set supautils.constrained_extensions to '{"plrust": []}';
select pg_reload_conf();
 pg_reload_conf
----------------
 t
(1 row)
-- next time
alter system  set supautils.constrained_extensions to '{"plrust": []}';
ERROR:  supautils.constrained_extensions: unexpected array
```

With this change:

```sql
-- works first time
alter system  set supautils.constrained_extensions to '{"x": []}';
ERROR:  supautils.constrained_extensions: unexpected array
```

The fix was using a check_hook in addition to the assign_hook.

This also improves the tests checking this behavior.