### PR TITLE
feat: pin an extension version

### DIFF
--- a/src/extensions_parameter_overrides.c
+++ b/src/extensions_parameter_overrides.c
@@ -21,6 +21,10 @@ static JSON_ACTION_RETURN_TYPE json_object_start(void *state) {
     parse->error_msg = "unexpected object for schema, expected a value";
     parse->state     = JEPO_UNEXPECTED_OBJECT;
     break;
+  case JEPO_EXPECT_VERSION:
+    parse->error_msg = "unexpected object for version, expected a value";
+    parse->state     = JEPO_UNEXPECTED_OBJECT;
+    break;
   default: break;
   }
   JSON_ACTION_RETURN;
@@ -54,9 +58,12 @@ json_object_field_start(void *state, char *fname,
   case JEPO_EXPECT_PARAMETER_OVERRIDES_START:
     if (strcmp(fname, "schema") == 0)
       parse->state = JEPO_EXPECT_SCHEMA;
+    else if (strcmp(fname, "version") == 0)
+      parse->state = JEPO_EXPECT_VERSION;
     else {
-      parse->state     = JEPO_UNEXPECTED_FIELD;
-      parse->error_msg = "unexpected field, only schema is allowed";
+      parse->state = JEPO_UNEXPECTED_FIELD;
+      parse->error_msg =
+          "unexpected field, only schema and version are allowed";
     }
     break;
 
@@ -78,6 +85,16 @@ static JSON_ACTION_RETURN_TYPE json_scalar(void *state, char *token,
     } else {
       parse->state     = JEPO_UNEXPECTED_SCHEMA_VALUE;
       parse->error_msg = "unexpected schema value, expected a string";
+    }
+    break;
+
+  case JEPO_EXPECT_VERSION:
+    if (tokentype == JSON_TOKEN_STRING) {
+      x->version   = MemoryContextStrdup(TopMemoryContext, token);
+      parse->state = JEPO_EXPECT_PARAMETER_OVERRIDES_START;
+    } else {
+      parse->state     = JEPO_UNEXPECTED_VERSION_VALUE;
+      parse->error_msg = "unexpected version value, expected a string";
     }
     break;
 
@@ -130,21 +147,31 @@ parse_extensions_parameter_overrides(const char                    *str,
 List *override_ext_options(extension_stmt_kind stmt_kind, const char *extname,
                            List *options, const size_t total_epos,
                            const extension_parameter_overrides *epos) {
+
+  // The override is not applied for alter statements
+  if (stmt_kind == EXT_ALTER) return options;
+
   for (size_t i = 0; i < total_epos; i++) {
     if (strcmp(epos[i].name, extname) == 0) {
-      const extension_parameter_overrides *epo                    = &epos[i];
-      DefElem                             *schema_option          = NULL;
-      DefElem                             *schema_override_option = NULL;
+      const extension_parameter_overrides *epo                     = &epos[i];
+      DefElem                             *schema_option           = NULL;
+      DefElem                             *schema_override_option  = NULL;
+      DefElem                             *version_option          = NULL;
+      DefElem                             *version_override_option = NULL;
       ListCell                            *option_cell;
-
-      // The schema override is not applied for alter statements
-      if (stmt_kind == EXT_ALTER) continue;
 
       // TODO for observability it would be good to log a warning here,
       // when the user specifies a different schema than the one in the override
       if (epo->schema != NULL) {
         Node *schema_node      = (Node *)makeString(pstrdup(epo->schema));
         schema_override_option = makeDefElem("schema", schema_node, -1);
+      }
+
+      // Note that new_version is the internal DefElem postgres uses for an
+      // CREATE/ALTER EXTENSION version target
+      if (epo->version != NULL) {
+        Node *version_node      = (Node *)makeString(pstrdup(epo->version));
+        version_override_option = makeDefElem("new_version", version_node, -1);
       }
 
       foreach (option_cell, options) {
@@ -156,6 +183,12 @@ List *override_ext_options(extension_stmt_kind stmt_kind, const char *extname,
                             errmsg("conflicting or redundant options")));
           }
           schema_option = defel;
+        } else if (strcmp(defel->defname, "new_version") == 0) {
+          if (version_option != NULL) {
+            ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),
+                            errmsg("conflicting or redundant options")));
+          }
+          version_option = defel;
         }
       }
 
@@ -164,6 +197,13 @@ List *override_ext_options(extension_stmt_kind stmt_kind, const char *extname,
           options = list_delete_ptr(options, schema_option);
         }
         options = lappend(options, schema_override_option);
+      }
+
+      if (version_override_option != NULL) {
+        if (version_option != NULL) {
+          options = list_delete_ptr(options, version_option);
+        }
+        options = lappend(options, version_override_option);
       }
     }
   }

--- a/src/extensions_parameter_overrides.h
+++ b/src/extensions_parameter_overrides.h
@@ -6,6 +6,7 @@
 typedef struct {
   char *name;
   char *schema;
+  char *version;
 } extension_parameter_overrides;
 
 typedef enum {
@@ -13,11 +14,13 @@ typedef enum {
   JEPO_EXPECT_TOPLEVEL_FIELD,
   JEPO_EXPECT_PARAMETER_OVERRIDES_START,
   JEPO_EXPECT_SCHEMA,
+  JEPO_EXPECT_VERSION,
   JEPO_UNEXPECTED_FIELD,
   JEPO_UNEXPECTED_ARRAY,
   JEPO_UNEXPECTED_SCALAR,
   JEPO_UNEXPECTED_OBJECT,
-  JEPO_UNEXPECTED_SCHEMA_VALUE
+  JEPO_UNEXPECTED_SCHEMA_VALUE,
+  JEPO_UNEXPECTED_VERSION_VALUE
 } json_extension_parameter_overrides_semantic_state;
 
 typedef struct {

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -1023,6 +1023,7 @@ static void clear_extensions_parameter_overrides_array(
   for (size_t i = 0; i < count; i++) {
     if (target[i].name != NULL) pfree(target[i].name);
     if (target[i].schema != NULL) pfree(target[i].schema);
+    if (target[i].version != NULL) pfree(target[i].version);
   }
   memset(target, 0, sizeof(extension_parameter_overrides) * count);
 }

--- a/test/expected/extension_parameter_override.out
+++ b/test/expected/extension_parameter_override.out
@@ -9,10 +9,27 @@ alter system set supautils.extensions_parameter_overrides to '{"sslinfo": 123}';
 ERROR:  supautils.extensions_parameter_overrides: unexpected scalar, expected an object
 alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"schema": {}}}';
 ERROR:  supautils.extensions_parameter_overrides: unexpected object for schema, expected a value
-alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"version": "1.0"}}';
-ERROR:  supautils.extensions_parameter_overrides: unexpected field, only schema is allowed
+alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"version": {}}}';
+ERROR:  supautils.extensions_parameter_overrides: unexpected object for version, expected a value
+alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"unknown": "1.0"}}';
+ERROR:  supautils.extensions_parameter_overrides: unexpected field, only schema and version are allowed
 alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"schema": 123}}';
 ERROR:  supautils.extensions_parameter_overrides: unexpected schema value, expected a string
+alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"version": 123}}';
+ERROR:  supautils.extensions_parameter_overrides: unexpected version value, expected a string
+\echo
+
+alter system set supautils.extensions_parameter_overrides to
+  '{"sslinfo":{"schema":"pg_catalog"},"hstore":{"version":"1.6"}}';
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\echo
+
+set role privileged_role;
 \echo
 
 -- can force sslinfo to be installed in pg_catalog
@@ -24,3 +41,33 @@ select extnamespace::regnamespace from pg_extension where extname = 'sslinfo';
 (1 row)
 
 drop extension sslinfo;
+\echo
+
+-- can force hstore to a configured version on create and alter
+create extension hstore version '1.7';
+select extversion from pg_extension where extname = 'hstore';
+ extversion 
+------------
+ 1.6
+(1 row)
+
+alter extension hstore update to '1.7';
+ERROR:  must be owner of extension hstore
+select extversion from pg_extension where extname = 'hstore';
+ extversion 
+------------
+ 1.6
+(1 row)
+
+drop extension hstore;
+\echo
+
+reset role;
+alter system set supautils.extensions_parameter_overrides to
+  '{"sslinfo":{"schema":"pg_catalog"}}';
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+

--- a/test/sql/extension_parameter_override.sql
+++ b/test/sql/extension_parameter_override.sql
@@ -4,8 +4,18 @@ alter system set supautils.extensions_parameter_overrides to '[]';
 alter system set supautils.extensions_parameter_overrides to '1';
 alter system set supautils.extensions_parameter_overrides to '{"sslinfo": 123}';
 alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"schema": {}}}';
-alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"version": "1.0"}}';
+alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"version": {}}}';
+alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"unknown": "1.0"}}';
 alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"schema": 123}}';
+alter system set supautils.extensions_parameter_overrides to '{"sslinfo": {"version": 123}}';
+\echo
+
+alter system set supautils.extensions_parameter_overrides to
+  '{"sslinfo":{"schema":"pg_catalog"},"hstore":{"version":"1.6"}}';
+select pg_reload_conf();
+\echo
+
+set role privileged_role;
 \echo
 
 -- can force sslinfo to be installed in pg_catalog
@@ -13,3 +23,18 @@ create extension sslinfo schema public;
 select extnamespace::regnamespace from pg_extension where extname = 'sslinfo';
 
 drop extension sslinfo;
+\echo
+
+-- can force hstore to a configured version on create and alter
+create extension hstore version '1.7';
+select extversion from pg_extension where extname = 'hstore';
+alter extension hstore update to '1.7';
+select extversion from pg_extension where extname = 'hstore';
+
+drop extension hstore;
+\echo
+
+reset role;
+alter system set supautils.extensions_parameter_overrides to
+  '{"sslinfo":{"schema":"pg_catalog"}}';
+select pg_reload_conf();


### PR DESCRIPTION
Solves https://github.com/supabase/supautils/pull/187.

By doing:

```sql
supautils.extensions_parameter_overrides = '{"hstore":{"version":"1.7"}}';
```

We can pin an extension to a version, even if the user creates it with a different one:

```sql
create extension hstore version '1.4';

select extversion from pg_extension where extname = 'hstore';
 extversion
------------
 1.7
(1 row)
```

ALTERing a extension doesn't work already but this is unrelated to this feature:

```sql
alter extension hstore update to '1.8';
ERROR:  must be owner of extension hstore

select extversion from pg_extension where extname = 'hstore';
 extversion
------------
 1.7
(1 row)
```

The ideal behavior for this is allowing the ALTER to succeed but forcing the version we specified. To solve this both https://github.com/supabase/supautils/issues/118 and https://github.com/supabase/supautils/issues/203 have to be cleared first.

However as it is, this is sufficient for solving https://github.com/supabase/supautils/pull/187.