### PR TITLE
fix: segfault on GRANT/REVOKE role with current_user/session_user/public grantee

### DIFF
--- a/src/extension_custom_scripts.c
+++ b/src/extension_custom_scripts.c
@@ -70,7 +70,7 @@ void run_global_before_create_script(
   ListCell *option_cell = NULL;
 
   foreach (option_cell, options) {
-    DefElem *defel = (DefElem *)lfirst(option_cell);
+    DefElem *defel = lfirst_node(DefElem, option_cell);
 
     if (strcmp(defel->defname, "schema") == 0) {
       d_schema  = defel;
@@ -102,7 +102,7 @@ void run_ext_before_create_script(
   char      filename[MAXPGPATH];
 
   foreach (option_cell, options) {
-    DefElem *defel = (DefElem *)lfirst(option_cell);
+    DefElem *defel = lfirst_node(DefElem, option_cell);
 
     if (strcmp(defel->defname, "schema") == 0) {
       d_schema  = defel;
@@ -134,7 +134,7 @@ void run_ext_after_create_script(
   char      filename[MAXPGPATH];
 
   foreach (option_cell, options) {
-    DefElem *defel = (DefElem *)lfirst(option_cell);
+    DefElem *defel = lfirst_node(DefElem, option_cell);
 
     if (strcmp(defel->defname, "schema") == 0) {
       d_schema  = defel;

--- a/src/extensions_parameter_overrides.c
+++ b/src/extensions_parameter_overrides.c
@@ -148,7 +148,7 @@ List *override_ext_options(extension_stmt_kind stmt_kind, const char *extname,
       }
 
       foreach (option_cell, options) {
-        DefElem *defel = (DefElem *)lfirst(option_cell);
+        DefElem *defel = lfirst_node(DefElem, option_cell);
 
         if (strcmp(defel->defname, "schema") == 0) {
           if (schema_option != NULL) {

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -286,7 +286,7 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
 
     // Setting the superuser attribute is not allowed.
     foreach (option_cell, stmt->options) {
-      DefElem *defel = (DefElem *)lfirst(option_cell);
+      DefElem *defel = lfirst_node(DefElem, option_cell);
       if (strcmp(defel->defname, "superuser") == 0) {
         ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
                         errmsg("permission denied to alter role"),
@@ -385,7 +385,7 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
 
       /* Check to see if there are any descriptions related to membership. */
       foreach (option_cell, stmt->options) {
-        DefElem *defel = (DefElem *)lfirst(option_cell);
+        DefElem *defel = lfirst_node(DefElem, option_cell);
         if (strcmp(defel->defname, "addroleto") == 0)
           addroleto = (List *)defel->arg;
 
@@ -407,7 +407,7 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
       if (addroleto) {
         ListCell *role_cell;
         foreach (role_cell, addroleto) {
-          RoleSpec *rolemember = lfirst(role_cell);
+          RoleSpec *rolemember = lfirst_node(RoleSpec, role_cell);
           confirm_reserved_memberships(get_rolespec_name(rolemember));
         }
       }
@@ -466,7 +466,7 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
       ListCell     *item;
 
       foreach (item, stmt->roles) {
-        RoleSpec *role = lfirst(item);
+        RoleSpec *role = lfirst_node(RoleSpec, item);
 
         /*
          * We check only for a named role being dropped; we ignore
@@ -496,7 +496,7 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
       /* GRANT <reserved_role> TO <role> */
       if (stmt->is_grant) {
         foreach (role_cell, stmt->granted_roles) {
-          AccessPriv *priv = (AccessPriv *)lfirst(role_cell);
+          AccessPriv *priv = lfirst_node(AccessPriv, role_cell);
           confirm_reserved_memberships(priv->priv_name);
         }
       }
@@ -508,10 +508,11 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
        * REVOKE <role> FROM <reserved_roles>
        */
       foreach (grantee_role_cell, stmt->grantee_roles) {
-        AccessPriv *priv = (AccessPriv *)lfirst(grantee_role_cell);
+        RoleSpec *spec = lfirst_node(RoleSpec, grantee_role_cell);
+        char     *role_name = get_rolespec_name(spec);
         // privileged_role can do GRANT <role> to <reserved_role>
-        if (is_reserved_role(priv->priv_name, role_is_privileged))
-          EREPORT_RESERVED_ROLE(priv->priv_name);
+        if (is_reserved_role(role_name, role_is_privileged))
+          EREPORT_RESERVED_ROLE(role_name);
       }
     }
     break;

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -508,7 +508,7 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
        * REVOKE <role> FROM <reserved_roles>
        */
       foreach (grantee_role_cell, stmt->grantee_roles) {
-        RoleSpec *spec = lfirst_node(RoleSpec, grantee_role_cell);
+        RoleSpec *spec      = lfirst_node(RoleSpec, grantee_role_cell);
         char     *role_name = get_rolespec_name(spec);
         // privileged_role can do GRANT <role> to <reserved_role>
         if (is_reserved_role(role_name, role_is_privileged))

--- a/test/expected/reserved_roles.out
+++ b/test/expected/reserved_roles.out
@@ -95,6 +95,24 @@ alter role current_user set search_path to 'test';
 ERROR:  "supabase_storage_admin" is a reserved role, only superusers can modify it
 \echo
 
+-- granting or revoking role membership with current_user/session_user must not crash
+set role rolecreator;
+grant non_reserved to current_user;
+revoke non_reserved from current_user;
+grant non_reserved to session_user;
+revoke non_reserved from session_user;
+grant non_reserved to public;
+ERROR:  role "public" does not exist
+\echo
+
+-- cannot bypass the reserved-role grantee check by using current_user
+set role anon;
+grant non_reserved to current_user;
+ERROR:  "anon" is a reserved role, only superusers can modify it
+revoke non_reserved from current_user;
+ERROR:  "anon" is a reserved role, only superusers can modify it
+\echo
+
 -- use a role that has the SUPERUSER privilege
 set role postgres;
 \echo

--- a/test/sql/reserved_roles.sql
+++ b/test/sql/reserved_roles.sql
@@ -73,6 +73,21 @@ set role supabase_storage_admin;
 alter role current_user set search_path to 'test';
 \echo
 
+-- granting or revoking role membership with current_user/session_user must not crash
+set role rolecreator;
+grant non_reserved to current_user;
+revoke non_reserved from current_user;
+grant non_reserved to session_user;
+revoke non_reserved from session_user;
+grant non_reserved to public;
+\echo
+
+-- cannot bypass the reserved-role grantee check by using current_user
+set role anon;
+grant non_reserved to current_user;
+revoke non_reserved from current_user;
+\echo
+
 -- use a role that has the SUPERUSER privilege
 set role postgres;
 \echo


### PR DESCRIPTION
## Problem

`GRANT test_role TO current_user;` from a non-superuser crashes the backend with signal 11 (reported in SU-419080, on `supabase-postgres-17.6.1.141`). `REVOKE ... FROM current_user` and `session_user`/`public` grantees crash the same way. Explicit role names work fine, which is why this survived since 2021 (`bd670dd`).

## Root cause

The `T_GrantRoleStmt` handler cast `stmt->grantee_roles` cells to `AccessPriv`, but the grammar builds that list from `role_list`, which produces `RoleSpec` nodes ([gram.y](https://github.com/postgres/postgres/blob/REL_17_10/src/backend/parser/gram.y#L7911), consumed as RoleSpec in [user.c](https://github.com/postgres/postgres/blob/REL_17_10/src/backend/commands/user.c#L1534)). The two structs place `priv_name` and `rolename` at the same byte offset, so named grantees accidentally read the correct string; for special role specs `rolename` is NULL ("filled only for ROLESPEC_CSTRING") and `is_reserved_role` segfaults on `strcmp(NULL, ...)`.

## Fix

- Treat grantees as `RoleSpec` and resolve them with `get_rolespec_name()`, matching the ALTER ROLE paths fixed in #185. Side effects, both upstream-consistent: `GRANT ... TO public` now errors `role "public" does not exist` exactly like vanilla Postgres, and a reserved role can no longer be granted memberships via `current_user` self-reference.
- Replace the remaining raw casts of parse-node list cells with `lfirst_node` (`supautils.c`, `extension_custom_scripts.c`, `extensions_parameter_overrides.c`) so the cassert builds in CI verify node tags on every access.
- Regression tests in `reserved_roles.sql` covering grant/revoke to `current_user`/`session_user`/`public`, including the reserved-grantee case.

Verified on PG 17.6: previously-crashing statements now return normal permission errors identical to explicit-name equivalents; `privileged_role`, `reserved_memberships`, `reserved_roles`, `extension_custom_scripts` suites pass.

Linear: https://linear.app/supabase/issue/PSQL-1413/fix-supautils-crash-on-grant-to-current-user
