### PR TITLE
feat: permit `COMMENT ON POLICY` in `supautils.policy_grants`

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ With supautils, this can be done like so:
 supautils.policy_grants = '{ "my_role": ["public.not_my_table", "public.also_not_my_table"] }'
 ```
 
-This allows `my_role` to manage policies for `public.not_my_table` and `public.also_not_my_table` without being an owner of these tables.
+This allows `my_role` to manage policies for `public.not_my_table` and `public.also_not_my_table` without being an owner of these tables. This includes `CREATE POLICY`, `ALTER POLICY`, `DROP POLICY` and `COMMENT ON POLICY`.
 
 #### Drop Triggers
 

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -894,6 +894,34 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
     if (superuser()) {
       break;
     }
+
+    /**
+     * COMMENT ON POLICY
+     */
+    if (((CommentStmt *)utility_stmt)->objtype == OBJECT_POLICY) {
+      CommentStmt *stmt              = (CommentStmt *)utility_stmt;
+      List        *object            = castNode(List, stmt->object);
+      List        *table_name_list   = list_truncate(
+          list_copy(object), list_length(object) - 1);
+      RangeVar    *table_range_var                 = makeRangeVarFromNameList(table_name_list);
+      bool        already_switched_to_superuser = false;
+
+      if (!is_current_role_granted_table_policy(table_range_var, pgs, total_pgs)) {
+        break;
+      }
+
+      switch_to_superuser(supautils_superuser, &already_switched_to_superuser);
+
+      run_process_utility_hook_with_cleanup(
+          prev_hook, already_switched_to_superuser, switch_to_original_role);
+
+      if (!already_switched_to_superuser) {
+        switch_to_original_role();
+      }
+
+      return;
+    }
+
     if (((CommentStmt *)utility_stmt)->objtype != OBJECT_EXTENSION) {
       break;
     }

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -899,14 +899,15 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
      * COMMENT ON POLICY
      */
     if (((CommentStmt *)utility_stmt)->objtype == OBJECT_POLICY) {
-      CommentStmt *stmt              = (CommentStmt *)utility_stmt;
-      List        *object            = castNode(List, stmt->object);
-      List        *table_name_list   = list_truncate(
-          list_copy(object), list_length(object) - 1);
-      RangeVar    *table_range_var                 = makeRangeVarFromNameList(table_name_list);
-      bool        already_switched_to_superuser = false;
+      CommentStmt *stmt   = (CommentStmt *)utility_stmt;
+      List        *object = castNode(List, stmt->object);
+      List        *table_name_list =
+          list_truncate(list_copy(object), list_length(object) - 1);
+      RangeVar *table_range_var = makeRangeVarFromNameList(table_name_list);
+      bool      already_switched_to_superuser = false;
 
-      if (!is_current_role_granted_table_policy(table_range_var, pgs, total_pgs)) {
+      if (!is_current_role_granted_table_policy(table_range_var, pgs,
+                                                total_pgs)) {
         break;
       }
 

--- a/test/expected/privileged_role.out.in
+++ b/test/expected/privileged_role.out.in
@@ -203,6 +203,7 @@ grant usage on schema allow_policies to privileged_role;
 set role privileged_role;
 create policy p on allow_policies.my_table for select using (true);
 alter policy p on allow_policies.my_table using (false);
+comment on policy p on allow_policies.my_table is 'a comment';
 drop policy p on allow_policies.my_table;
 set role postgres;
 drop schema allow_policies cascade;
@@ -221,6 +222,8 @@ create policy p2 on deny_policies.my_table for select using (true);
 ERROR:  must be owner of table my_table
 alter policy p1 on deny_policies.my_table using (false);
 ERROR:  must be owner of table my_table
+comment on policy p1 on deny_policies.my_table is 'a comment';
+ERROR:  must be owner of relation my_table
 drop policy p1 on deny_policies.my_table;
 ERROR:  must be owner of relation my_table
 set role postgres;

--- a/test/sql/privileged_role.sql
+++ b/test/sql/privileged_role.sql
@@ -143,6 +143,7 @@ grant usage on schema allow_policies to privileged_role;
 set role privileged_role;
 create policy p on allow_policies.my_table for select using (true);
 alter policy p on allow_policies.my_table using (false);
+comment on policy p on allow_policies.my_table is 'a comment';
 drop policy p on allow_policies.my_table;
 
 set role postgres;
@@ -159,6 +160,7 @@ grant usage on schema deny_policies to privileged_role;
 set role privileged_role;
 create policy p2 on deny_policies.my_table for select using (true);
 alter policy p1 on deny_policies.my_table using (false);
+comment on policy p1 on deny_policies.my_table is 'a comment';
 drop policy p1 on deny_policies.my_table;
 
 set role postgres;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Permit `COMMENT ON POLICY` in `supautils.policy_grants`.

## What is the current behavior?

```
comment on policy "TEST" on realtime.messages is 'TEST COMMENT';

=> ERROR: 42501: must be owner of relation messages
```

## Additional context

We started [restricting the realtime schema](https://github.com/supabase/realtime/pull/1993) recently to stop users from dropping and modifying Realtime objects, which has been a source of problems for a very long time. That restriction was possible because the [Realtime tables are included in supabase.policy_grants](https://github.com/supabase/postgres/blob/4ffca2ad6b4e7132632c74868d5a5cad243de199/ansible/files/postgresql_config/supautils.conf.j2#L2) already but `COMMENT ON POLICY` is not allowed currently, although that's a common statement and some projects need it.

More info on REAL-920