### PR TITLE
chore: remove nixConfig from flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ If you are a repo member, you can skip building for hours and download packages 
 
 3. Use the cache:
   ```sh
-  nix run nixpkgs#cachix use nxpg
+  sudo nix run nixpkgs#cachix use nxpg
   ```
 
 > [!CAUTION]

--- a/README.md
+++ b/README.md
@@ -339,14 +339,51 @@ The hint is only included when there are lacking `SELECT`, `INSERT`, `UPDATE` or
 
 ## Development
 
-[Nix](https://nixos.org/download.html) is required to set up the environment.
+Nix with flakes is required.
+
+### Set up Nix
+
+First, [Install Nix](https://nixos.org/download.html).
+
+#### Enable flakes
+
+Edit `/etc/nix/nix.conf`, add:
+
+```nix.conf
+experimental-features = nix-command flakes
+```
+
+and restart the daemon, on macOS:
+
+```
+sudo launchctl kickstart -k system/org.nixos.nix-daemon
+```
+
+#### Use binary cache
+
+If you are a repo member, you can skip building for hours and download packages instead by configuring the `nxpg` binary cache.
+
+1. Go to https://app.cachix.org, log in with Github and create a **personal auth token**.
+
+2. Use auth token:
+  ```sh
+  nix run nixpkgs#cachix authtoken <token>
+  ```
+
+3. Use the cache:
+  ```sh
+  nix run nixpkgs#cachix use nxpg
+  ```
+
+> [!CAUTION]
+> DO NOT use `trusted-users` in `/etc/nix/nix.conf` as it [grants root without password](https://nix.dev/manual/nix/stable/command-ref/conf-file.html#conf-trusted-users). Instead, add the binary cache to `extra-substituters` and `extra-trusted-public-keys`.
 
 ### Testing
 
 For testing the module locally, execute:
 
 ```bash
-# This will download all the dependencies from the cache (when prompted for trusting the nxpg cache answer yes)
+# Open a development shell with all deps and tools present
 $ nix develop
 
 # test on pg 13

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,6 @@
 {
   description = "Development shell for supautils";
 
-  nixConfig = {
-    extra-substituters = [
-      "https://nxpg.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "nxpg.cachix.org-1:6HKVOmmG/ptPEogBAJ+zR6kRji5F4uHTNx7EGt7WBh0="
-    ];
-  };
-
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/91c9a64ce2a84e648d0cf9671274bb9c2fb9ba60";
     xpg = {


### PR DESCRIPTION
## Why
`nixConfig.extra-substituters` only applies to trusted users, so everyone else sees:

> warning: ignoring untrusted substituter '...', you are not a trusted user

That warning invites people to add themselves to `trusted-users`, which is actually a local privilege-escalation vector ([Nix manual](https://nix.dev/manual/nix/stable/command-ref/conf-file#conf-trusted-users), see also SEC-894), not a config gap to fix.

See the [binary cache docs](https://github.com/supabase/postgres/blob/develop/nix/docs/binary-cache.md) in postgres to set them up correctly.

## What
Remove `nixConfig` from `flake.nix`. Add README docs on how to set up nix with flakes and binary cache.