### PR TITLE
chore: bump MODVERSION to 3.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PG_CFLAGS += --coverage
 endif
 
 MODULE_big = supautils
-MODVERSION = 3.2.3
+MODVERSION = 3.3.0
 
 SRC_DIR = src
 


### PR DESCRIPTION
Bumps `MODVERSION` in the `Makefile` from `3.2.3` to `3.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XB9oRRpks6nJsy6Mr9rYKg)_