### PR TITLE
chore: bump module version 3.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PG_CFLAGS += --coverage
 endif
 
 MODULE_big = supautils
-MODVERSION = 3.2.3
+MODVERSION = 3.3.0
 
 SRC_DIR = src
 


### PR DESCRIPTION
Bumps `MODVERSION` in the Makefile from `3.2.3` to `3.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)