### PR TITLE
fix: restore global state when an error occurs while elevated

### DIFF
--- a/src/extension_custom_scripts.c
+++ b/src/extension_custom_scripts.c
@@ -47,15 +47,28 @@ static void run_custom_script(const char *filename, const char *extname,
            sql_literal(extname), sql_literal(extschema),
            sql_literal(extversion), extcascade ? "'true'" : "'false'");
 
-  PushActiveSnapshot(GetTransactionSnapshot());
-  SPI_connect();
+  // Ensure the recursion guard is cleared even if the script (or any of the SPI
+  // calls) throws, otherwise custom scripts would be silently skipped for the
+  // rest of the session.
+  PG_TRY();
+  {
+    PushActiveSnapshot(GetTransactionSnapshot());
+    SPI_connect();
 
-  int rc = SPI_execute(sql, false, 0);
-  if (rc != SPI_OK_UTILITY) {
-    elog(ERROR, "SPI_execute failed with error code %d", rc);
+    int rc = SPI_execute(sql, false, 0);
+    if (rc != SPI_OK_UTILITY) {
+      elog(ERROR, "SPI_execute failed with error code %d", rc);
+    }
+    SPI_finish();
+    PopActiveSnapshot();
   }
-  SPI_finish();
-  PopActiveSnapshot();
+  PG_CATCH();
+  {
+    running_custom_script = false;
+    PG_RE_THROW();
+  }
+  PG_END_TRY();
+
   running_custom_script = false;
 }
 

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -620,30 +620,44 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
 
     switch_to_superuser(supautils_superuser, &already_switched_to_superuser);
 
-    run_global_before_create_script(stmt->extname, stmt->options,
-                                    extension_custom_scripts_path);
+    // The custom scripts below run arbitrary user provided SQL, and the whole
+    // region runs elevated. Wrap it all so an ERROR anywhere cannot leave the
+    // role switch state stuck, which would stop later elevations.
+    PG_TRY();
+    {
+      run_global_before_create_script(stmt->extname, stmt->options,
+                                      extension_custom_scripts_path);
 
-    run_ext_before_create_script(stmt->extname, stmt->options,
-                                 extension_custom_scripts_path);
+      run_ext_before_create_script(stmt->extname, stmt->options,
+                                   extension_custom_scripts_path);
 
-    stmt->options = override_ext_options(EXT_CREATE, stmt->extname,
-                                         stmt->options, total_epos, epos);
+      stmt->options = override_ext_options(EXT_CREATE, stmt->extname,
+                                           stmt->options, total_epos, epos);
 
-    if (is_extension_privileged(stmt->extname, privileged_extensions)) {
-      run_process_utility_hook_with_cleanup(
-          prev_hook, already_switched_to_superuser, switch_to_original_role);
-    } else {
+      if (is_extension_privileged(stmt->extname, privileged_extensions)) {
+        run_process_utility_hook(prev_hook);
+      } else {
+        if (!already_switched_to_superuser) {
+          switch_to_original_role();
+        }
+
+        run_process_utility_hook(prev_hook);
+
+        switch_to_superuser(supautils_superuser,
+                            &already_switched_to_superuser);
+      }
+
+      run_ext_after_create_script(stmt->extname, stmt->options,
+                                  extension_custom_scripts_path);
+    }
+    PG_CATCH();
+    {
       if (!already_switched_to_superuser) {
         switch_to_original_role();
       }
-
-      run_process_utility_hook(prev_hook);
-
-      switch_to_superuser(supautils_superuser, &already_switched_to_superuser);
+      PG_RE_THROW();
     }
-
-    run_ext_after_create_script(stmt->extname, stmt->options,
-                                extension_custom_scripts_path);
+    PG_END_TRY();
 
     if (!already_switched_to_superuser) {
       switch_to_original_role();
@@ -736,13 +750,25 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
 
     switch_to_superuser(supautils_superuser, &already_switched_to_superuser);
 
-    run_process_utility_hook_with_cleanup(
-        prev_hook, already_switched_to_superuser, switch_to_original_role);
+    // alter_owner() also runs elevated and can throw, so it has to be inside
+    // the protected region too, not just the utility hook.
+    PG_TRY();
+    {
+      run_process_utility_hook(prev_hook);
 
-    CreateFdwStmt *stmt = (CreateFdwStmt *)utility_stmt;
+      CreateFdwStmt *stmt = (CreateFdwStmt *)utility_stmt;
 
-    // Change FDW owner to the current role (which is a privileged role)
-    alter_owner(stmt->fdwname, current_user_id, ALT_FDW);
+      // Change FDW owner to the current role (which is a privileged role)
+      alter_owner(stmt->fdwname, current_user_id, ALT_FDW);
+    }
+    PG_CATCH();
+    {
+      if (!already_switched_to_superuser) {
+        switch_to_original_role();
+      }
+      PG_RE_THROW();
+    }
+    PG_END_TRY();
 
     if (!already_switched_to_superuser) {
       switch_to_original_role();
@@ -767,13 +793,26 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
 
     switch_to_superuser(supautils_superuser, &already_switched_to_superuser);
 
-    run_process_utility_hook_with_cleanup(
-        prev_hook, already_switched_to_superuser, switch_to_original_role);
+    // alter_owner() also runs elevated and can throw, so it has to be inside
+    // the protected region too, not just the utility hook.
+    PG_TRY();
+    {
+      run_process_utility_hook(prev_hook);
 
-    CreatePublicationStmt *stmt = (CreatePublicationStmt *)utility_stmt;
+      CreatePublicationStmt *stmt = (CreatePublicationStmt *)utility_stmt;
 
-    // Change publication owner to the current role (which is a privileged role)
-    alter_owner(stmt->pubname, current_user_id, ALT_PUB);
+      // Change publication owner to the current role (which is a privileged
+      // role)
+      alter_owner(stmt->pubname, current_user_id, ALT_PUB);
+    }
+    PG_CATCH();
+    {
+      if (!already_switched_to_superuser) {
+        switch_to_original_role();
+      }
+      PG_RE_THROW();
+    }
+    PG_END_TRY();
 
     if (!already_switched_to_superuser) {
       switch_to_original_role();
@@ -1099,13 +1138,25 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
 
       switch_to_superuser(supautils_superuser, &already_switched_to_superuser);
 
-      run_process_utility_hook_with_cleanup(
-          prev_hook, already_switched_to_superuser, switch_to_original_role);
+      // alter_owner() also runs elevated and can throw, so it has to be inside
+      // the protected region too, not just the utility hook.
+      PG_TRY();
+      {
+        run_process_utility_hook(prev_hook);
 
-      if (!current_user_is_super)
-        // Change event trigger owner to the current role (which is a privileged
-        // role)
-        alter_owner(stmt->trigname, current_user_id, ALT_EVTRIG);
+        if (!current_user_is_super)
+          // Change event trigger owner to the current role (which is a
+          // privileged role)
+          alter_owner(stmt->trigname, current_user_id, ALT_EVTRIG);
+      }
+      PG_CATCH();
+      {
+        if (!already_switched_to_superuser) {
+          switch_to_original_role();
+        }
+        PG_RE_THROW();
+      }
+      PG_END_TRY();
 
       if (!already_switched_to_superuser) {
         switch_to_original_role();

--- a/src/utils.c
+++ b/src/utils.c
@@ -19,19 +19,36 @@ void switch_to_superuser(const char *supauser, bool *already_switched) {
   if (*already_switched) {
     return;
   }
-  is_switched_to_superuser = true;
 
+  // get_role_oid() can throw, so resolve the target before touching any global
+  // state. That way is_switched_to_superuser is never left true with a
+  // half-initialized prev_role_*, which switch_to_original_role() would then
+  // restore from.
   if (supauser != NULL) {
     superuser_oid = get_role_oid(supauser, false);
   }
 
   GetUserIdAndSecContext(&prev_role_oid, &prev_role_sec_context);
+
+  // SetUserIdAndSecContext() only assigns CurrentUserId and
+  // SecurityRestrictionContext, it cannot throw, so once prev_role_* is
+  // captured the switch below always completes.
   SetUserIdAndSecContext(superuser_oid, prev_role_sec_context |
                                             SECURITY_LOCAL_USERID_CHANGE |
                                             SECURITY_RESTRICTED_OPERATION);
+
+  is_switched_to_superuser = true;
 }
 
 void switch_to_original_role(void) {
+  // Idempotent, so error cleanup paths can call this unconditionally without
+  // risking restoring a stale prev_role_* on top of an already restored role.
+  // is_switched_to_superuser is only true once prev_role_* is valid and the
+  // switch has completed, see switch_to_superuser().
+  if (!is_switched_to_superuser) {
+    return;
+  }
+
   SetUserIdAndSecContext(prev_role_oid, prev_role_sec_context);
   is_switched_to_superuser = false;
 }

--- a/test/expected/extension_custom_scripts.out
+++ b/test/expected/extension_custom_scripts.out
@@ -46,3 +46,55 @@ drop table t2;
 set role extensions_role;
 \echo
 
+-- global state is restored when a custom script errors
+-- (terse errors, the CONTEXT would contain the machine dependent scripts path)
+\set VERBOSITY terse
+create extension plls;
+ERROR:  failing custom script
+\set VERBOSITY default
+\echo
+
+-- the original role is restored after the error
+select current_role;
+  current_role   
+-----------------
+ extensions_role
+(1 row)
+
+\echo
+
+-- elevation still works after the error
+create extension hstore;
+select '1=>2'::hstore;
+  hstore  
+----------
+ "1"=>"2"
+(1 row)
+
+drop extension hstore;
+-- sslinfo can only be created by a superuser, so this proves supautils still
+-- elevates after the failed custom script
+create extension sslinfo;
+select extowner::regrole from pg_extension where extname = 'sslinfo';
+ extowner 
+----------
+ postgres
+(1 row)
+
+drop extension sslinfo;
+\echo
+
+-- custom scripts still run after the error
+create extension fuzzystrmatch;
+drop extension fuzzystrmatch;
+select * from t2;
+ column1 
+---------
+       1
+(1 row)
+
+reset role;
+drop table t2;
+set role extensions_role;
+\echo
+

--- a/test/init.sh
+++ b/test/init.sh
@@ -19,3 +19,7 @@ echo 'create extension citext;' > "$TMPDIR/extension-custom-scripts/autoinc/afte
 mkdir -p "$TMPDIR/extension-custom-scripts/fuzzystrmatch"
 echo 'create table t1();' > "$TMPDIR/extension-custom-scripts/fuzzystrmatch/before-create.sql"
 echo 'drop table t1; create table t2 as values (1);' > "$TMPDIR/extension-custom-scripts/fuzzystrmatch/after-create.sql"
+
+# a custom script that always fails, to assert global state is restored on error
+mkdir -p "$TMPDIR/extension-custom-scripts/plls"
+echo "do \$\$ begin raise exception 'failing custom script'; end \$\$;" > "$TMPDIR/extension-custom-scripts/plls/before-create.sql"

--- a/test/sql/extension_custom_scripts.sql
+++ b/test/sql/extension_custom_scripts.sql
@@ -35,3 +35,36 @@ select * from t2;
 drop table t2;
 set role extensions_role;
 \echo
+
+-- global state is restored when a custom script errors
+-- (terse errors, the CONTEXT would contain the machine dependent scripts path)
+\set VERBOSITY terse
+create extension plls;
+\set VERBOSITY default
+\echo
+
+-- the original role is restored after the error
+select current_role;
+\echo
+
+-- elevation still works after the error
+create extension hstore;
+select '1=>2'::hstore;
+drop extension hstore;
+
+-- sslinfo can only be created by a superuser, so this proves supautils still
+-- elevates after the failed custom script
+create extension sslinfo;
+select extowner::regrole from pg_extension where extname = 'sslinfo';
+drop extension sslinfo;
+\echo
+
+-- custom scripts still run after the error
+create extension fuzzystrmatch;
+drop extension fuzzystrmatch;
+select * from t2;
+
+reset role;
+drop table t2;
+set role extensions_role;
+\echo


### PR DESCRIPTION
Fixes #215

## Summary

PostgreSQL `ERROR` restores backend state, but not Supautils' process-local
bookkeeping. An error while running privileged extension work could therefore
leave `is_switched_to_superuser` and `running_custom_script` stuck for the
rest of the backend session.

This caused later privileged operations to stop elevating and later extension
custom scripts to be silently skipped.

## Fix

- restore temporary state through `PG_CATCH` paths that re-throw the original
  error
- protect the full elevated `CREATE EXTENSION` flow, including custom scripts
- include `alter_owner()` in the protected region for FDWs, publications, and
  event triggers
- only mark the superuser switch active after the switch has completed
- make role restoration safe when no switch is active

## Testing

Added a regression that intentionally fails a privileged extension custom
script and then verifies, in the same backend, that:

- the original error reaches the client
- the original role is restored
- a later superuser-only extension can still be created
- a later extension custom script still executes

Validated builds and focused regressions on PostgreSQL 13, 14, 15, 16, 17,
and 18.

The broader PostgreSQL 17 suite has one unrelated `permission_hints` failure
that reproduces on unmodified `master`.

Testing was performed using a Docker-based replication of the repository test
harness because Nix/xpg was unavailable locally.
