### PR TITLE
fix: enforce extension schema overrides on ALTER EXTENSION

### DIFF
--- a/src/extensions_parameter_overrides.c
+++ b/src/extensions_parameter_overrides.c
@@ -140,6 +140,16 @@ parse_extensions_parameter_overrides(const char                    *str,
   return state;
 }
 
+const char *get_ext_schema_override(const char  *extname,
+                                    const size_t total_epos,
+                                    const extension_parameter_overrides *epos) {
+  for (size_t i = 0; i < total_epos; i++) {
+    if (strcmp(epos[i].name, extname) == 0) return epos[i].schema;
+  }
+
+  return NULL;
+}
+
 List *override_ext_options(extension_stmt_kind stmt_kind, const char *extname,
                            List *options, const size_t total_epos,
                            const extension_parameter_overrides *epos) {
@@ -150,7 +160,11 @@ List *override_ext_options(extension_stmt_kind stmt_kind, const char *extname,
       DefElem                             *schema_override_option = NULL;
       ListCell                            *option_cell;
 
-      // The schema override is not applied for alter statements
+      // The schema override is not applied for alter statements.
+      // ALTER EXTENSION only accepts the "new_version" option, so injecting a
+      // "schema" one here would make postgres fail with "unrecognized option".
+      // ALTER EXTENSION ... SET SCHEMA is a different statement
+      // (AlterObjectSchemaStmt) and is pinned to the override separately.
       if (stmt_kind == EXT_ALTER) continue;
 
       // TODO for observability it would be good to log a warning here,

--- a/src/extensions_parameter_overrides.h
+++ b/src/extensions_parameter_overrides.h
@@ -41,4 +41,10 @@ extern List *override_ext_options(extension_stmt_kind stmt_kind,
                                   const size_t total_epos,
                                   const extension_parameter_overrides *epos);
 
+// Returns the configured schema override for extname, or NULL when the
+// extension has no override or its override doesn't set a schema.
+extern const char *
+get_ext_schema_override(const char *extname, const size_t total_epos,
+                        const extension_parameter_overrides *epos);
+
 #endif

--- a/src/supautils.c
+++ b/src/supautils.c
@@ -684,11 +684,28 @@ static void supautils_hook(PROCESS_UTILITY_PARAMS) {
    * ALTER EXTENSION <extension> SET SCHEMA
    */
   case T_AlterObjectSchemaStmt: {
+    AlterObjectSchemaStmt *stmt = (AlterObjectSchemaStmt *)pstmt->utilityStmt;
+
+    /*
+     * Keep the extension pinned to its configured schema override. Force the
+     * destination back instead of erroring out, mirroring how CREATE EXTENSION
+     * silently overrides a conflicting SCHEMA clause. Since the extension
+     * already is in that schema, postgres turns this into a no-op.
+     *
+     * This is done before the privilege checks below because an override can
+     * be configured for an extension that is not in privileged_extensions,
+     * and because CREATE EXTENSION applies overrides to superusers too.
+     */
+    if (stmt->objectType == OBJECT_EXTENSION) {
+      const char *schema_override =
+          get_ext_schema_override(strVal(stmt->object), total_epos, epos);
+
+      if (schema_override != NULL) stmt->newschema = pstrdup(schema_override);
+    }
+
     if (superuser()) {
       break;
     }
-
-    AlterObjectSchemaStmt *stmt = (AlterObjectSchemaStmt *)pstmt->utilityStmt;
 
     if (stmt->objectType == OBJECT_EXTENSION &&
         is_extension_privileged(strVal(stmt->object), privileged_extensions)) {

--- a/test/expected/extension_parameter_override.out
+++ b/test/expected/extension_parameter_override.out
@@ -42,3 +42,80 @@ select extnamespace::regnamespace from pg_extension where extname = 'sslinfo';
 (1 row)
 
 drop extension sslinfo;
+\echo
+
+-- the schema override cannot be bypassed with ALTER EXTENSION ... SET SCHEMA
+create schema other_schema;
+grant all on schema other_schema to extensions_role, nonsuper;
+\echo
+
+-- as a non-superuser, for an extension in supautils.privileged_extensions
+set role extensions_role;
+create extension sslinfo schema public;
+select extnamespace::regnamespace from pg_extension where extname = 'sslinfo';
+ extnamespace 
+--------------
+ pg_catalog
+(1 row)
+
+alter extension sslinfo set schema other_schema;
+select extnamespace::regnamespace from pg_extension where extname = 'sslinfo';
+ extnamespace 
+--------------
+ pg_catalog
+(1 row)
+
+-- the extension is still usable
+select ssl_is_used();
+ ssl_is_used 
+-------------
+ f
+(1 row)
+
+\echo
+
+-- an extension without an override is not pinned
+create extension hstore schema public;
+alter extension hstore set schema other_schema;
+select extnamespace::regnamespace from pg_extension where extname = 'hstore';
+ extnamespace 
+--------------
+ other_schema
+(1 row)
+
+drop extension hstore;
+reset role;
+drop extension sslinfo;
+\echo
+
+-- as a superuser, since the override also applies to superusers on create
+create extension sslinfo schema public;
+select extnamespace::regnamespace from pg_extension where extname = 'sslinfo';
+ extnamespace 
+--------------
+ pg_catalog
+(1 row)
+
+alter extension sslinfo set schema other_schema;
+select extnamespace::regnamespace from pg_extension where extname = 'sslinfo';
+ extnamespace 
+--------------
+ pg_catalog
+(1 row)
+
+drop extension sslinfo;
+\echo
+
+-- non-extension objects can still be moved between schemas
+set role nonsuper;
+create table public.override_tbl();
+alter table public.override_tbl set schema other_schema;
+select relnamespace::regnamespace from pg_class where relname = 'override_tbl';
+ relnamespace 
+--------------
+ other_schema
+(1 row)
+
+drop table other_schema.override_tbl;
+reset role;
+drop schema other_schema;

--- a/test/sql/extension_parameter_override.sql
+++ b/test/sql/extension_parameter_override.sql
@@ -30,3 +30,52 @@ create extension sslinfo schema public;
 select extnamespace::regnamespace from pg_extension where extname = 'sslinfo';
 
 drop extension sslinfo;
+\echo
+
+-- the schema override cannot be bypassed with ALTER EXTENSION ... SET SCHEMA
+create schema other_schema;
+grant all on schema other_schema to extensions_role, nonsuper;
+\echo
+
+-- as a non-superuser, for an extension in supautils.privileged_extensions
+set role extensions_role;
+create extension sslinfo schema public;
+select extnamespace::regnamespace from pg_extension where extname = 'sslinfo';
+
+alter extension sslinfo set schema other_schema;
+select extnamespace::regnamespace from pg_extension where extname = 'sslinfo';
+
+-- the extension is still usable
+select ssl_is_used();
+\echo
+
+-- an extension without an override is not pinned
+create extension hstore schema public;
+alter extension hstore set schema other_schema;
+select extnamespace::regnamespace from pg_extension where extname = 'hstore';
+
+drop extension hstore;
+reset role;
+drop extension sslinfo;
+\echo
+
+-- as a superuser, since the override also applies to superusers on create
+create extension sslinfo schema public;
+select extnamespace::regnamespace from pg_extension where extname = 'sslinfo';
+
+alter extension sslinfo set schema other_schema;
+select extnamespace::regnamespace from pg_extension where extname = 'sslinfo';
+
+drop extension sslinfo;
+\echo
+
+-- non-extension objects can still be moved between schemas
+set role nonsuper;
+create table public.override_tbl();
+alter table public.override_tbl set schema other_schema;
+select relnamespace::regnamespace from pg_class where relname = 'override_tbl';
+
+drop table other_schema.override_tbl;
+reset role;
+
+drop schema other_schema;


### PR DESCRIPTION
Fixes #203

## Summary

`supautils.extensions_parameter_overrides` already pins an extension's schema
during `CREATE EXTENSION`, but `ALTER EXTENSION ... SET SCHEMA` could move it
out of the configured schema afterward.

`ALTER EXTENSION ... SET SCHEMA` is represented as an
`AlterObjectSchemaStmt`, so it never reaches the existing
`override_ext_options()` handling used by `CREATE EXTENSION`.

## Fix

When an extension has a configured schema override, force the
`AlterObjectSchemaStmt` destination back to that configured schema.

This matches the existing CREATE behavior: the command still succeeds, but
the configured override remains authoritative.

The enforcement is independent of `privileged_extensions`, so it also applies
to superusers and to overridden extensions that do not use Supautils'
privilege-elevation path.

## Tests

Extended `extension_parameter_override` coverage to verify that:

- conflicting `CREATE EXTENSION ... SCHEMA` remains pinned
- `ALTER EXTENSION ... SET SCHEMA` cannot bypass the override as a
  non-superuser
- the same applies to superusers
- the extension remains usable afterward
- extensions without an override remain relocatable
- non-extension `ALTER ... SET SCHEMA` behavior is unchanged

Focused regression tests and builds passed on PostgreSQL 13, 14, 15, 16, 17,
and 18.

The official Nix/xpg environment was unavailable locally, so validation used
a Docker reproduction of the repository's regression-test sequence.
