### PR TITLE
fix: exclude vendor folder from style check

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -44,12 +44,12 @@ let
   style = pkgs.writeShellScriptBin "supautils-style" ''
     set -euo pipefail
 
-    ${pkgs.clang-tools}/bin/clang-format -i src/*
+    ${pkgs.clang-tools}/bin/clang-format -i src/*.c src/*.h
   '';
   styleCheck = pkgs.writeShellScriptBin "supautils-style-check" ''
     set -euo pipefail
 
-    ${pkgs.clang-tools}/bin/clang-format -i src/*
+    ${pkgs.clang-tools}/bin/clang-format -i src/*.c src/*.h
     ${pkgs.git}/bin/git diff-index --exit-code HEAD -- '*.c'
   '';
   loadtestUtility = pkgs.writeShellScriptBin "supautils-loadtest-utility" ''


### PR DESCRIPTION
The files inside the `src/vendor` folder were also being style checked. This PR excludes them to keep them the same as the original source for easy diffing.