### PR TITLE
chore(ci): add read-only workflow permissions on main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   test:
 


### PR DESCRIPTION
Fixes following code scanning alerts:

* https://github.com/supabase/supautils/security/code-scanning/1
* https://github.com/supabase/supautils/security/code-scanning/2
* https://github.com/supabase/supautils/security/code-scanning/3
* https://github.com/supabase/supautils/security/code-scanning/4
* https://github.com/supabase/supautils/security/code-scanning/5
* https://github.com/supabase/supautils/security/code-scanning/6